### PR TITLE
Update Claude thinking config

### DIFF
--- a/agent/src/typedefs.py
+++ b/agent/src/typedefs.py
@@ -112,7 +112,7 @@ class AnthropicParams(EngineParams):
     model: str = Field(..., description="Anthropic model name (e.g., claude-3-sonnet-20240229)")
     
     # Anthropic-specific fields
-    thinking: bool = Field(False, description="Enable thinking mode for Claude")
+    thinking: Optional[dict[str, Any]] = Field(None, description="Thinking mode config for Claude")
     top_p: Optional[float] = Field(None, ge=0.0, le=1.0, description="Nucleus sampling parameter")
     top_k: Optional[int] = Field(None, gt=0, description="Top-k sampling parameter")
 

--- a/config/models/claude-4-sonnet.yaml
+++ b/config/models/claude-4-sonnet.yaml
@@ -1,3 +1,6 @@
 engine_type: anthropic
 model: claude-sonnet-4-20250514
 temperature: 1.0
+thinking:
+  type: disabled  # change to "enabled" and set a budget_tokens value to enable thinking
+  budget_tokens: 0


### PR DESCRIPTION
# Description

Update default YAML config and associated `AnthropicEngineParams` to support thinking mode for Anthropic.

The default is still disabled.

# Tests

A small sample of 10 experiments returned without error.
