### PR TITLE
[FEAT] Support GPT-5

### DIFF
--- a/agent/src/typedefs.py
+++ b/agent/src/typedefs.py
@@ -1,7 +1,7 @@
 """ Type definitions used throughout the simulator. """
 
 from enum import StrEnum
-from typing import Optional, Any, Dict, List, NewType
+from typing import Optional, Any, Dict, List, NewType, Literal
 
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage, ToolCall
 from pydantic import BaseModel, Field, field_validator, ConfigDict, SecretStr
@@ -103,6 +103,7 @@ class OpenAIParams(EngineParams):
     frequency_penalty: Optional[float] = Field(None, ge=-2.0, le=2.0, description="Frequency penalty")
     presence_penalty: Optional[float] = Field(None, ge=-2.0, le=2.0, description="Presence penalty")
     stop: Optional[List[str]] = Field(None, description="Stop sequences")
+    reasoning_effort: Optional[Literal["minimal"]] = Field(None)
 
 
 class AnthropicParams(EngineParams):

--- a/config/models/gpt-5.yaml
+++ b/config/models/gpt-5.yaml
@@ -1,0 +1,3 @@
+engine_type: openai
+model: gpt-5-chat-latest
+temperature: 1.0

--- a/config/models/gpt-5.yaml
+++ b/config/models/gpt-5.yaml
@@ -1,3 +1,4 @@
 engine_type: openai
-model: gpt-5-chat-latest
+model: gpt-5
 temperature: 1.0
+reasoning_effort: minimal

--- a/config/models/gpt-5.yaml
+++ b/config/models/gpt-5.yaml
@@ -2,4 +2,3 @@ engine_type: openai
 model: gpt-5
 temperature: 1.0
 reasoning_effort: minimal
-max_tokens: 1024

--- a/config/models/gpt-5.yaml
+++ b/config/models/gpt-5.yaml
@@ -2,3 +2,4 @@ engine_type: openai
 model: gpt-5
 temperature: 1.0
 reasoning_effort: minimal
+max_tokens: 1024

--- a/experiments/runners/batch_runtime/providers/openai/serializer.py
+++ b/experiments/runners/batch_runtime/providers/openai/serializer.py
@@ -39,16 +39,22 @@ class OpenAIBatchProviderSerializer(BaseBatchProviderSerializer):
         tools: list[dict[str, Any]] = None,
     ) -> ProviderBatchRequest:
         """Serialization of a single experiment."""
+        body: dict[str, Any] = {
+            "model": engine_params.model,
+            "messages": raw_messages,
+        }
+
+        if engine_params.temperature is not None:
+            body["temperature"] = engine_params.temperature
+
+        if engine_params.max_new_tokens is not None:
+            body["max_tokens"] = engine_params.max_new_tokens
+
         batch_request: dict[str, Any] = {
             "custom_id": custom_id,
             "method": "POST",
             "url": "/v1/chat/completions",
-            "body": {
-                "model": engine_params.model,
-                "messages": raw_messages,
-                "max_tokens": engine_params.max_new_tokens,
-                "temperature": engine_params.temperature,
-            },
+            "body": body,
         }
 
         if tools:

--- a/experiments/runners/batch_runtime/providers/openai/serializer.py
+++ b/experiments/runners/batch_runtime/providers/openai/serializer.py
@@ -55,4 +55,8 @@ class OpenAIBatchProviderSerializer(BaseBatchProviderSerializer):
             batch_request["body"]["tools"] = tools
             batch_request["body"]["tool_choice"] = "auto"
 
+        reasoning_effort = getattr(engine_params, "reasoning_effort", None)
+        if reasoning_effort is not None:
+            batch_request["body"]["reasoning_effort"] = reasoning_effort
+
         return ProviderBatchRequest(batch_request)


### PR DESCRIPTION
# Description

Closes #14

- Add gpt-5 model config
- Add `reasoning_effort` field to `OpenAIParams` and `OpenAIBatchProviderSerializer`
- **refactor(serializer): Simplify body construction in `OpenAIBatchProviderSerializer`**


# Test

A small batch test was completed successfully
