### PR TITLE
[UDL][1/n] Fix Screenshot Validation

### DIFF
--- a/experiments/runners/screenshot_runtime/base.py
+++ b/experiments/runners/screenshot_runtime/base.py
@@ -90,15 +90,12 @@ class BaseScreenshotRuntime(BaseEvaluationRuntime, ABC):
     def validate_prerequisites(self) -> bool:
         """Validate any prerequisites before running experiments."""
         if self.validation_service:
+            experiments_list = list(self.experiments_iter)
             return self.validation_service.validate_all_screenshots(
-                self.get_experiments_dataframe(), self.get_dataset_path()
+                experiments_list,
+                self.get_dataset_path(),
             )
         return True
-
-    @abstractmethod
-    def get_experiments_dataframe(self):
-        """Get the experiments dataframe for validation."""
-        pass
 
     @abstractmethod
     def get_dataset_path(self) -> Optional[str]:

--- a/experiments/runners/screenshot_runtime/hf_hub_dataset.py
+++ b/experiments/runners/screenshot_runtime/hf_hub_dataset.py
@@ -76,10 +76,6 @@ class HFHubDatasetRuntime(BaseScreenshotRuntime):
         """Return an iterator over experiments from the HF dataset."""
         return hf_experiments_iter(self.hf_dataset_name, subset=self.subset)
 
-    def get_experiments_dataframe(self):
-        """HF datasets don't have a dataframe representation."""
-        return None
-
     def get_dataset_path(self) -> Optional[str]:
         """HF datasets don't have a local path."""
         return None

--- a/experiments/runners/screenshot_runtime/local_dataset.py
+++ b/experiments/runners/screenshot_runtime/local_dataset.py
@@ -90,10 +90,6 @@ class LocalDatasetRuntime(BaseScreenshotRuntime):
         """Return an iterator over experiments from the local dataset."""
         return experiments_iter(self.dataset, self.dataset_name)
 
-    def get_experiments_dataframe(self):
-        """Get the experiments dataframe for validation."""
-        return self.dataset
-
     def get_dataset_path(self) -> Optional[str]:
         """Get the dataset path for screenshot regeneration."""
         return self.local_dataset_path

--- a/experiments/runners/services/screenshot_validation.py
+++ b/experiments/runners/services/screenshot_validation.py
@@ -3,6 +3,7 @@ Screenshot validation service for batch and screenshot runtimes.
 """
 
 from pathlib import Path
+from typing import Optional
 
 from rich import print as _print
 from rich.progress import (BarColumn, Progress, SpinnerColumn, TextColumn,
@@ -25,7 +26,7 @@ class ScreenshotValidationService:
         self.debug_mode = debug_mode
 
     def validate_all_screenshots(
-        self, experiments: list[ExperimentData], local_dataset_path: str
+        self, experiments: list[ExperimentData], local_dataset_path: Optional[str]
     ) -> bool:
         """
         Validate that all required screenshots exist.
@@ -33,6 +34,10 @@ class ScreenshotValidationService:
         Returns:
             True if all screenshots exist and are valid
         """
+        if not local_dataset_path:
+            # Remote datasets don't require local screenshot validation
+            return True
+
         _print("[bold blue]Validating screenshot availability...")
 
         if not ensure_all_screenshots_exist(experiments, local_dataset_path):


### PR DESCRIPTION
# Description

Closes #20

- Remove redundant `get_experiments_dataframe` and enhance validation logic with dataset name and optional path handling

# Test

- Successful execution of screenshot runtime from local dataset
- Successful execution of screenshot runtime from HF Hub dataset
