### PR TITLE
[UDL][5/n] Fix `remote` argument

### DIFF
--- a/experiments/filesystem_environment.py
+++ b/experiments/filesystem_environment.py
@@ -13,7 +13,7 @@ class FilesystemShoppingEnvironment(BaseShoppingEnvironment):
     This is useful for replaying experiments or testing with pre-captured screenshots.
     """
     
-    def __init__(self, screenshots_dir: Path, query: str, experiment_label: str, experiment_number: int, dataset_name: str, remote: bool = False):
+    def __init__(self, screenshots_dir: Path, query: str, experiment_label: str, experiment_number: int, dataset_name: str, remote: bool):
         """
         Initialize the filesystem environment.
         

--- a/experiments/runners/batch_runtime/orchestrator.py
+++ b/experiments/runners/batch_runtime/orchestrator.py
@@ -32,12 +32,12 @@ class BatchOrchestratorRuntime(BaseEvaluationRuntime):
     def __init__(
         self,
         engine_params_list: List[EngineParams],
+        remote: bool,
         output_dir_override: Optional[str] = None,
         experiment_count_limit: Optional[int] = None,
         experiment_label_filter: Optional[str] = None,
         debug_mode: bool = False,
         force_submit: bool = False,
-        remote: bool = False,
         monitor_interval: int = DEFAULT_MONITOR_INTERVAL,
         local_dataset_path: Optional[str] = None,
         hf_dataset_name: Optional[str] = None,
@@ -90,12 +90,12 @@ class BatchOrchestratorRuntime(BaseEvaluationRuntime):
             )
         self.simulator = AgentSimulator(
             dataset_name=self.dataset_name,
+            run_output_dir=self.run_output_dir,
+            use_remote=self.remote,
             local_dataset_path=dataset_path,
             hf_dataset_name=hf_dataset_name,
             hf_subset=hf_subset,
             screenshots_dir=self.screenshots_dir,
-            run_output_dir=self.run_output_dir,
-            use_remote=self.remote,
             verbose=self.debug_mode,
         )
 

--- a/experiments/runners/screenshot_runtime/base.py
+++ b/experiments/runners/screenshot_runtime/base.py
@@ -27,12 +27,12 @@ class ScreenshotRuntime(BaseEvaluationRuntime):
     def __init__(
         self,
         engine_params_list: List[EngineParams],
+        remote: bool,
         output_dir_override: Optional[str] = None,
         max_concurrent_per_engine: int = 5,
         experiment_count_limit: Optional[int] = None,
         experiment_label_filter: Optional[str] = None,
         debug_mode: bool = False,
-        remote: bool = False,
         local_dataset_path: Optional[str] = None,
         hf_dataset_name: Optional[str] = None,
         hf_subset: str = "all",

--- a/experiments/runners/services/agent_simulator.py
+++ b/experiments/runners/services/agent_simulator.py
@@ -27,11 +27,11 @@ class AgentSimulator:
         self,
         dataset_name: str,
         run_output_dir: Path,
+        use_remote: bool,
         local_dataset_path: Optional[str] = None,
         hf_dataset_name: Optional[str] = None,
         hf_subset: str = "all",
         screenshots_dir: Optional[Path] = None,
-        use_remote: bool = False,
         verbose: bool = False,
     ):
         self.dataset_name = dataset_name

--- a/run.py
+++ b/run.py
@@ -79,11 +79,11 @@ async def main():
 
             runtime = ScreenshotRuntime(
                 engine_params_list=model_configs,
+                remote=args.remote,
                 max_concurrent_per_engine=MAX_CONCURRENT_MODELS,
                 experiment_count_limit=EXPERIMENT_COUNT_LIMIT,
                 experiment_label_filter=EXPERIMENT_LABEL_FILTER,
                 debug_mode=args.debug,
-                remote=args.remote,
                 local_dataset_path=args.local_dataset,
                 hf_dataset_name=None if args.local_dataset else hf_dataset,
                 hf_subset=args.subset if not args.local_dataset else "all",
@@ -94,14 +94,14 @@ async def main():
             batch_hf_dataset = None if args.local_dataset else hf_dataset
             batch_hf_subset = args.subset if not args.local_dataset else "all"
             runtime = BatchOrchestratorRuntime(
+                engine_params_list=model_configs,
+                remote=args.remote,
                 local_dataset_path=args.local_dataset,
                 hf_dataset_name=batch_hf_dataset,
                 hf_subset=batch_hf_subset,
-                engine_params_list=model_configs,
                 experiment_count_limit=args.experiment_count_limit,
                 debug_mode=args.debug,
                 force_submit=args.force_submit,
-                remote=args.remote,
             )
             runtime.run()
         case _:

--- a/tests/runners/test_screenshot_runtime.py
+++ b/tests/runners/test_screenshot_runtime.py
@@ -108,6 +108,7 @@ class TestScreenshotRuntime:
             loader,
             mock_engine_params,
             local_dataset_path=str(dataset_path),
+            remote=False,
         ) as (runtime, loader_cls, validation_cls, validation_instance):
             expected_call = dict(
                 engine_params=mock_engine_params,
@@ -133,6 +134,7 @@ class TestScreenshotRuntime:
             mock_engine_params,
             hf_dataset_name="my/dataset",
             hf_subset="subset",
+            remote=False,
         ) as (runtime, loader_cls, validation_cls, _):
             expected_call = dict(
                 engine_params=mock_engine_params,
@@ -155,6 +157,7 @@ class TestScreenshotRuntime:
             loader,
             mock_engine_params,
             hf_dataset_name="my/dataset",
+            remote=False,
         ) as (runtime, _, _, _):
             experiments = list(runtime.experiments_iter)
             assert experiments == [sample_experiment]
@@ -211,6 +214,7 @@ class TestScreenshotRuntime:
                 loader,
                 mock_engine_params,
                 hf_dataset_name="my/dataset",
+                remote=False,
             ) as (runtime, _, _, _):
                 environment = runtime.create_shopping_environment(sample_experiment)
 
@@ -226,6 +230,7 @@ class TestScreenshotRuntime:
             loader,
             mock_engine_params,
             hf_dataset_name="my/dataset",
+            remote=False,
         ) as (runtime, _, _, _):
             with pytest.raises(ValueError, match="No screenshot found"):
                 runtime.create_shopping_environment(sample_experiment)
@@ -245,6 +250,7 @@ class TestScreenshotRuntime:
             loader,
             mock_engine_params,
             local_dataset_path=str(dataset_path),
+            remote=False,
         ) as (runtime, _, _, validation_instance):
             validation_instance.validate_all_screenshots.return_value = True
             assert runtime.validate_prerequisites() is True
@@ -263,6 +269,7 @@ class TestScreenshotRuntime:
             loader,
             mock_engine_params,
             local_dataset_path=str(dataset_path),
+            remote=False,
         ) as (runtime, _, _, _):
             assert runtime.get_dataset_path() == str(dataset_path)
 


### PR DESCRIPTION
# Description

Closes #17

- Ensure that `remote` defaults to `0`
- Make `remote` a required parameter across runtimes, simulators, and tests

# Test

- Ran screenshot runtime with `remote`, without GCS args. Successfully errored, indicating proper use of `remote` flag.
- Ran screenshot runtime without `remote`, without GCS args. Success.
- Ran batch runtime with `remote`, without GCS args. Successfully errored, indicating proper use of `remote` flag.
- Ran batch runtime without `remote`, without GCS args. Success.
- Ran screenshot runtime with `remote`, with GCS args. Success.
- Ran batch runtime with `remote`, with GCS args. Success.
