### PR TITLE
[UDL][6/n] Remove HF Dataset Defaults & Add Guard

### DIFF
--- a/experiments/data_loader.py
+++ b/experiments/data_loader.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterable, Optional
 import pandas as pd
 from datasets import load_dataset, Image
 
@@ -70,7 +70,7 @@ def load_experiment_data(csv_path: str) -> pd.DataFrame:
     return pd.read_csv(csv_path)
 
 
-def hf_experiments_iter(dataset_name: str, subset: str = "all", split: str = "data") -> Iterable[ExperimentData]:
+def hf_experiments_iter(dataset_name: str, subset: Optional[str] = None, split: str = "data") -> Iterable[ExperimentData]:
     """
     Load a HuggingFace dataset and iterate over experiments.
     
@@ -87,7 +87,10 @@ def hf_experiments_iter(dataset_name: str, subset: str = "all", split: str = "da
         ExperimentData: Experiment configuration with expanded DataFrame
     """
     # Load the dataset
-    dataset = load_dataset(dataset_name, subset, split=split)
+    if subset is None:
+        dataset = load_dataset(dataset_name, split=split)
+    else:
+        dataset = load_dataset(dataset_name, subset, split=split)
     
     for row in dataset:
         # Extract scalar values

--- a/experiments/runners/batch_runtime/orchestrator.py
+++ b/experiments/runners/batch_runtime/orchestrator.py
@@ -41,7 +41,7 @@ class BatchOrchestratorRuntime(BaseEvaluationRuntime):
         monitor_interval: int = DEFAULT_MONITOR_INTERVAL,
         local_dataset_path: Optional[str] = None,
         hf_dataset_name: Optional[str] = None,
-        hf_subset: str = "all",
+        hf_subset: Optional[str] = None,
     ):
         """Initialize the simplified BatchEvaluationRuntime."""
         self.experiment_loader = ExperimentLoader(

--- a/experiments/runners/screenshot_runtime/base.py
+++ b/experiments/runners/screenshot_runtime/base.py
@@ -35,7 +35,7 @@ class ScreenshotRuntime(BaseEvaluationRuntime):
         debug_mode: bool = False,
         local_dataset_path: Optional[str] = None,
         hf_dataset_name: Optional[str] = None,
-        hf_subset: str = "all",
+        hf_subset: Optional[str] = None,
     ):
         """
         Initialize the unified screenshot runtime.

--- a/experiments/runners/services/agent_simulator.py
+++ b/experiments/runners/services/agent_simulator.py
@@ -30,7 +30,7 @@ class AgentSimulator:
         use_remote: bool,
         local_dataset_path: Optional[str] = None,
         hf_dataset_name: Optional[str] = None,
-        hf_subset: str = "all",
+        hf_subset: Optional[str] = None,
         screenshots_dir: Optional[Path] = None,
         verbose: bool = False,
     ):

--- a/experiments/runners/services/experiment_loader.py
+++ b/experiments/runners/services/experiment_loader.py
@@ -64,7 +64,7 @@ class _LocalDatasetSource(_DatasetSource):
 class _HFDatasetSource(_DatasetSource):
     """HuggingFace Hub dataset with embedded screenshots."""
 
-    def __init__(self, hf_dataset_name: str, subset: str = 'all'):
+    def __init__(self, hf_dataset_name: str, subset: Optional[str] = None):
         self.hf_dataset_name = hf_dataset_name
         self.subset = subset
         self._dataset_name = f"{hf_dataset_name.replace('/', '_')}_{subset}"
@@ -99,7 +99,7 @@ class ExperimentLoader(EncodedExperimentIdMixin):
         experiment_count_limit: Optional[int] = None,
         local_dataset_path: Optional[str] = None,
         hf_dataset_name: Optional[str] = None,
-        hf_subset: str = 'all',
+        hf_subset: Optional[str] = None,
     ):
         if local_dataset_path and hf_dataset_name:
             raise ValueError(

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import argparse
+from typing import Optional
 
 from dotenv import load_dotenv
 
@@ -28,6 +29,49 @@ DATASET_MAPPING = {
 
 DEFAULT_HF_DATASET = DATASET_MAPPING["rs"]
 
+DATASET_SUBSET_REQUIREMENTS = {
+    "My-Custom-AI/ACE-BB": ["choice_behavior", "market_share"],
+    "My-Custom-AI/ACE-SR": None,
+    "My-Custom-AI/ACE-RS": ["absolute_and_random_price", "instruction_following", "rating", "relative_price"],
+}
+
+def validate_dataset_subset(dataset_name: str, subset: Optional[str]) -> None:
+    """
+    Validate that the dataset and subset combination is correct.
+
+    Only validates known ACES datasets. For unknown datasets, no validation is performed.
+
+    Args:
+        dataset_name: Full HuggingFace dataset name (e.g., "My-Custom-AI/ACE-BB")
+        subset: Subset name or None
+
+    Raises:
+        ValueError: If the dataset/subset combination is invalid
+    """
+    if dataset_name not in DATASET_SUBSET_REQUIREMENTS:
+        return
+
+    valid_subsets = DATASET_SUBSET_REQUIREMENTS[dataset_name]
+
+    if valid_subsets is None:
+        if subset is not None:
+            raise ValueError(
+                f"Dataset {dataset_name} does not support subsets. "
+                f"Please omit the --subset argument."
+            )
+    else:
+        if subset is None:
+            raise ValueError(
+                f"Dataset {dataset_name} requires a subset. "
+                f"Valid subsets: {', '.join(valid_subsets)}"
+            )
+        if subset not in valid_subsets:
+            raise ValueError(
+                f"Invalid subset '{subset}' for dataset {dataset_name}. "
+                f"Valid subsets: {', '.join(valid_subsets)}"
+            )
+
+
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description='AI Agent Impact Evaluation')
@@ -38,8 +82,8 @@ def parse_args():
     parser.add_argument('--hf-dataset', type=str, default=DEFAULT_HF_DATASET,
                         help=f"Hugging Face dataset name to use (e.g., \"{DEFAULT_HF_DATASET}\")")
     parser.add_argument('--subset', type=str,
-                        help="Subset of ACERS dataset to use (e.g., 'sanity_checks', 'bias_experiments', 'all'). View dataset card for more details.",
-                        default="all")
+                        help="Subset of ACERS dataset to use (e.g., 'sanity_checks', 'bias_experiments'). View dataset card for more details.",
+                        default=None)
     parser.add_argument('--debug', action='store_true', default=DEBUG_MODE,
                         help='Enable debug mode')
     parser.add_argument('--remote', action='store_true', default=False,
@@ -65,7 +109,11 @@ async def main():
             hf_dataset = DATASET_MAPPING[args.hf_dataset]
         else:
             hf_dataset = args.hf_dataset
-    
+
+    # Validate dataset/subset combination for HuggingFace datasets
+    if hf_dataset and not args.local_dataset:
+        validate_dataset_subset(hf_dataset, args.subset)
+
     # Create and run the evaluation runtime
     # noinspection PyUnreachableCode
     match args.runtime_type:
@@ -86,19 +134,17 @@ async def main():
                 debug_mode=args.debug,
                 local_dataset_path=args.local_dataset,
                 hf_dataset_name=None if args.local_dataset else hf_dataset,
-                hf_subset=args.subset if not args.local_dataset else "all",
+                hf_subset=args.subset,
             )
             await runtime.run()
         case "batch":
             print("Using BatchEvaluationRuntime (for Batch processing APIs)")
-            batch_hf_dataset = None if args.local_dataset else hf_dataset
-            batch_hf_subset = args.subset if not args.local_dataset else "all"
             runtime = BatchOrchestratorRuntime(
                 engine_params_list=model_configs,
                 remote=args.remote,
                 local_dataset_path=args.local_dataset,
-                hf_dataset_name=batch_hf_dataset,
-                hf_subset=batch_hf_subset,
+                hf_dataset_name=None if args.local_dataset else hf_dataset,
+                hf_subset=args.subset,
                 experiment_count_limit=args.experiment_count_limit,
                 debug_mode=args.debug,
                 force_submit=args.force_submit,

--- a/tests/runners/test_screenshot_runtime.py
+++ b/tests/runners/test_screenshot_runtime.py
@@ -115,7 +115,7 @@ class TestScreenshotRuntime:
                 experiment_count_limit=None,
                 local_dataset_path=str(dataset_path),
                 hf_dataset_name=None,
-                hf_subset="all",
+                hf_subset=None,
             )
             loader_cls.assert_called_once_with(**expected_call)
             validation_cls.assert_called_once_with(


### PR DESCRIPTION
# Description

Closes #30

- Removes default subset "all"
- Adds guard to raise error on incorrect values

# Test

- Ran `--hf-dataset sr`. Success.
- Ran `--hf-dataset rs --subset blah`. Successfully errored. Catching incorrect value.
- Ran `--hdf-dataset rs --subset instruction_following`. Success.