### PR TITLE
[RENM][1/n] Update Gemini-related Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,23 +19,23 @@ dependencies = [
     "pandas>=2.3.3",
     "pillow>=12.0.0",
     "pydantic-settings>=2.12.0",
-    "pytest>=9.0.1",
     "python-dotenv>=1.2.1",
     "pyyaml>=6.0.3",
     "rich>=14.2.0",
     "selenium>=4.38.0",
-    "pandas-stubs>=2.3.2.250926",
     "fastapi>=0.122.0",
     "datasets>=4.4.1",
     "uvicorn>=0.38.0",
-    "pytest-asyncio>=1.3.0",
-    "isort>=7.0.0",
     "langchain-aws>=0.2.31",
 ]
 
 [dependency-groups]
 dev = [
     "ipykernel>=7.1.0",
+    "isort>=7.0.0",
+    "pandas-stubs>=2.3.2.250926",
+    "pytest>=9.0.1",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "google-cloud-aiplatform" },
     { name = "google-cloud-storage" },
-    { name = "isort" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-aws" },
@@ -42,11 +41,8 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "openai" },
     { name = "pandas" },
-    { name = "pandas-stubs" },
     { name = "pillow" },
     { name = "pydantic-settings" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -57,6 +53,10 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "isort" },
+    { name = "pandas-stubs" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -69,7 +69,6 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.122.0" },
     { name = "google-cloud-aiplatform", specifier = ">=1.128.0" },
     { name = "google-cloud-storage", specifier = ">=3.6.0" },
-    { name = "isort", specifier = ">=7.0.0" },
     { name = "langchain", specifier = ">=0.3.25" },
     { name = "langchain-anthropic", specifier = ">=0.3.12" },
     { name = "langchain-aws", specifier = ">=0.2.31" },
@@ -78,11 +77,8 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.3.21" },
     { name = "openai", specifier = ">=1.75.0" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "pandas-stubs", specifier = ">=2.3.2.250926" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
-    { name = "pytest", specifier = ">=9.0.1" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=14.2.0" },
@@ -91,7 +87,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ipykernel", specifier = ">=7.1.0" }]
+dev = [
+    { name = "ipykernel", specifier = ">=7.1.0" },
+    { name = "isort", specifier = ">=7.0.0" },
+    { name = "pandas-stubs", specifier = ">=2.3.2.250926" },
+    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
# Description

- Bumped `langchain-google-genai` and `google-cloud-aiplatform` to their respective latest releases.
- Removed obsolete `vertexai` package.
- Moved developer dependencies for better project organization.
- Updated all dependencies to their latest compatible versions.

This PR is in support of #37 and #41

# Tests

No major changes. Batch runtime exhibits expected behavior.
