### PR TITLE
[1/n] Resubmit Failed Batch Submissions

### DIFF
--- a/experiments/runners/batch_runtime/orchestrator.py
+++ b/experiments/runners/batch_runtime/orchestrator.py
@@ -319,6 +319,7 @@ class BatchOrchestratorRuntime(BaseEvaluationRuntime):
             )
 
     def run(self):
+        # TODO: simplify logic
         if self.monitor_only:
             _print("[bold blue]Monitor-only mode: skipping batch submission")
             self.experiment_tracker.load_submitted_experiments()

--- a/experiments/runners/batch_runtime/orchestrator.py
+++ b/experiments/runners/batch_runtime/orchestrator.py
@@ -185,7 +185,10 @@ class BatchOrchestratorRuntime(BaseEvaluationRuntime):
                 case _:
                     raise ValueError(f"Unsupported engine type: {engine_type}")
 
-    def _load_experiments(self) -> dict[EngineConfigName, list[ExperimentData]]:
+    def _load_experiments(self) -> tuple[
+        dict[EngineConfigName, list[ExperimentData]],
+        dict[EngineConfigName, set[ExperimentId]] | None,
+    ]:
         """Select, load, and prepare environment."""
         submitted_experiments = self.experiment_tracker.load_submitted_experiments()
 
@@ -223,7 +226,8 @@ class BatchOrchestratorRuntime(BaseEvaluationRuntime):
                     outstanding_experiments.values(), verbose=self.debug_mode
                 )
 
-        return outstanding_experiments
+        return outstanding_experiments, resubmit_failed_ids
+
     def _print_orphan_warnings(
         self, orphans: dict[EngineConfigName, dict[str, list[ExperimentId]]]
     ) -> None:
@@ -324,7 +328,8 @@ class BatchOrchestratorRuntime(BaseEvaluationRuntime):
             _print("[bold green]Batch monitoring complete!")
             return
 
-        outstanding_experiments = self._load_experiments()
+        outstanding_experiments, resubmit_failed_ids = self._load_experiments()
+
         # Print pre-submission summary
         self._print_submission_summary(outstanding_experiments, resubmit_failed_ids)
 

--- a/run.py
+++ b/run.py
@@ -93,6 +93,8 @@ def parse_args():
                         help='Force resubmission of batches, overriding submitted experiments tracking (batch runtime only)')
     parser.add_argument('--monitor-only', action='store_true', default=False,
                         help='Monitor existing batches without submitting new ones (batch runtime only)')
+    parser.add_argument('--resubmit-failures', action='store_true', default=False,
+                        help='Resubmit failed experiments (keeps failure records)')
     parser.add_argument('--experiment-count-limit', type=int, default=None,
                         help='Maximum number of experiments to run (for debugging)')
     return parser.parse_args()
@@ -150,6 +152,7 @@ async def main():
                 debug_mode=args.debug,
                 force_submit=args.force_submit,
                 monitor_only=args.monitor_only,
+                resubmit_failures=args.resubmit_failures,
             )
             runtime.run()
         case _:


### PR DESCRIPTION
Closes #88 

# Description

- Add `--resubmit-failed` to batch CLI
- When `resubmit_failed` enabled, failed submissions are read from batch metadata, and marked for resubmission.
- This facilitates ensuring all experiments are complete when the model fails without modifying the batch metadata

# Test

- No static type or linting errors
- All relevant tests pass
- This argument was used to ensure that all submissions for Anthropic models were properly submitted, and expected behavior was exhibited