### PR TITLE
feat(visualization): Add performance visualization scripts for sanity checks and position bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,16 +296,36 @@ uv run visualization sanity-checks all \
 
 **Output:** `artifacts/visualization/sanity_checks/`
 
+#### 5. Price-Equivalent Trade-offs (from choice model)
+Shows by what percentage a seller can raise (or must cut) price to keep utility constant when adding (or losing) a feature.
+
+```bash
+# Generate price-equivalent trade-off plots for all features
+# Creates 10 plots: 4 individual features + 1 combined (each with all_providers and by_provider versions)
+uv run visualization price-tradeoffs artifacts/analysis/20260122104301_choice_model.csv
+```
+
+**Output:** `artifacts/visualization/price_equivalent_tradeoffs/`
+
+**Features analyzed:**
+- **Overall Pick tag**: Price increase possible when adding this tag
+- **Rating +0.1**: Price increase possible when rating improves by 0.1
+- **Double Reviews**: Price increase possible when review count doubles
+- **Sponsored Tag**: Price cut needed to offset negative perception
+
+**Note:** Positive percentages indicate the seller can raise prices; negative percentages indicate the seller must cut prices.
+
 ### Visualization Output Structure
 
 All visualization plots are organized in subdirectories under `artifacts/visualization/`:
 
 ```
 artifacts/visualization/
-├── position_bias/       # Position bias across models
-├── heatmaps/           # 2×4 position probability heatmaps
-├── feature_impact/     # Feature impact on selection probability
-└── sanity_checks/      # Rationality suite sanity check failure rates
+├── position_bias/                  # Position bias across models
+├── heatmaps/                      # 2×4 position probability heatmaps
+├── feature_impact/                # Feature impact on selection probability
+├── sanity_checks/                 # Rationality suite sanity check failure rates
+└── price_equivalent_tradeoffs/    # Price-equivalent trade-offs for features
 ```
 
 Each visualization type generates plots grouped by provider (Anthropic, Google, OpenAI) showing model performance evolution by release date.

--- a/README.md
+++ b/README.md
@@ -256,17 +256,20 @@ Shows how features (rating, price, tags) impact selection probability.
 
 ```bash
 # Generate all feature impact plots (rating, price, sponsored tag, overall pick)
+# Creates 8 plots: both all_providers and by_provider versions for each feature
 uv run visualization feature-impact all artifacts/analysis/20260122104301_choice_model.csv
 
-# Or generate specific feature plots only:
-uv run visualization feature-impact rating artifacts/analysis/20260122104301_choice_model.csv
-uv run visualization feature-impact price artifacts/analysis/20260122104301_choice_model.csv
-uv run visualization feature-impact tags artifacts/analysis/20260122104301_choice_model.csv  # Generates both sponsored tag and overall pick
+# Or generate specific feature plots:
+uv run visualization feature-impact rating artifacts/analysis/20260122104301_choice_model.csv  # 2 plots
+uv run visualization feature-impact price artifacts/analysis/20260122104301_choice_model.csv   # 2 plots
+uv run visualization feature-impact tags artifacts/analysis/20260122104301_choice_model.csv    # 4 plots (2 per tag)
 ```
 
 **Output:** `artifacts/visualization/feature_impact/`
 
-**Note:** The `tags` command generates plots for both "Sponsored Tag" and "Overall Pick" features.
+**Note:**
+- Each command generates **both** `all_providers` (all models on one plot) and `by_provider` (3 subplots) versions
+- The `tags` command generates plots for both "Sponsored Tag" and "Overall Pick" features (4 plots total)
 
 #### 4. Sanity Checks (from rationality suite analysis)
 Visualizes sanity check failure rates across models for rating, price, and instruction following experiments.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,103 @@ uv run analysis rationality-suite rating experiment_logs/aggregated_experiment_d
 
 The `artifacts/analysis/` directory is the target output location of result CSV.
 
+## Visualization
+
+The `visualization` CLI generates plots from analysis results to visualize model performance, feature impacts, and sanity check failures.
+
+To use the `visualization` script, the `analysis` dependency group needs to be installed (same as Analysis above).
+
+```
+ Usage: visualization [OPTIONS] COMMAND [ARGS]...
+
+ Visualization CLI for generating plots from analysis results.
+
+╭─ Commands ───────────────────────────────────────────────────────────────╮
+│ position-bias     Generate position bias visualizations                  │
+│ heatmap          Generate position probability heatmaps                   │
+│ feature-impact   Generate feature impact visualizations                   │
+│ sanity-checks    Generate sanity check visualizations                     │
+╰──────────────────────────────────────────────────────────────────────────╯
+```
+
+### Visualization Types
+
+#### 1. Position Bias (from choice model)
+Visualizes how product position in the 2×4 grid affects selection probability.
+
+```bash
+# Generate position bias plots (all_providers.png + by_provider.png)
+uv run visualization position-bias artifacts/analysis/20260122104301_choice_model.csv
+```
+
+**Output:** `artifacts/visualization/position_bias/`
+
+#### 2. Heatmaps (from choice model)
+Generates 2×4 position probability heatmaps for each model.
+
+```bash
+# Generate heatmaps for all models
+uv run visualization heatmap artifacts/analysis/20260122104301_choice_model.csv
+```
+
+**Output:** `artifacts/visualization/heatmaps/`
+
+#### 3. Feature Impact (from choice model)
+Shows how features (rating, price, tags) impact selection probability.
+
+```bash
+# Generate all feature impact plots (rating, price, sponsored tag, overall pick)
+uv run visualization feature-impact all artifacts/analysis/20260122104301_choice_model.csv
+
+# Or generate specific feature plots only:
+uv run visualization feature-impact rating artifacts/analysis/20260122104301_choice_model.csv
+uv run visualization feature-impact price artifacts/analysis/20260122104301_choice_model.csv
+uv run visualization feature-impact tags artifacts/analysis/20260122104301_choice_model.csv  # Generates both sponsored tag and overall pick
+```
+
+**Output:** `artifacts/visualization/feature_impact/`
+
+**Note:** The `tags` command generates plots for both "Sponsored Tag" and "Overall Pick" features.
+
+#### 4. Sanity Checks (from rationality suite analysis)
+Visualizes sanity check failure rates across models for rating, price, and instruction following experiments.
+
+```bash
+# Generate rating sanity check plots
+uv run visualization sanity-checks rating artifacts/analysis/20260121184134_rating_sanity_check.csv
+
+# Generate price sanity check plots (combines price and ar_price data)
+uv run visualization sanity-checks price \
+  artifacts/analysis/20260212101910_price_sanity_check.csv \
+  artifacts/analysis/20260213120645_ar_price_sanity_check.csv
+
+# Generate instruction following plots
+uv run visualization sanity-checks instruction artifacts/analysis/20260212101915_instruction_sanity_check.csv
+
+# Generate ALL sanity check plots at once
+uv run visualization sanity-checks all \
+  artifacts/analysis/20260121184134_rating_sanity_check.csv \
+  artifacts/analysis/20260212101910_price_sanity_check.csv \
+  artifacts/analysis/20260213120645_ar_price_sanity_check.csv \
+  artifacts/analysis/20260212101915_instruction_sanity_check.csv
+```
+
+**Output:** `artifacts/visualization/sanity_checks/`
+
+### Visualization Output Structure
+
+All visualization plots are organized in subdirectories under `artifacts/visualization/`:
+
+```
+artifacts/visualization/
+├── position_bias/       # Position bias across models
+├── heatmaps/           # 2×4 position probability heatmaps
+├── feature_impact/     # Feature impact on selection probability
+└── sanity_checks/      # Rationality suite sanity check failure rates
+```
+
+Each visualization type generates plots grouped by provider (Anthropic, Google, OpenAI) showing model performance evolution by release date.
+
 ## Repository Layout
 
 ```

--- a/experiments/visualization/choice_model_position_bias.py
+++ b/experiments/visualization/choice_model_position_bias.py
@@ -212,7 +212,7 @@ def plot_by_provider(csv_path: Path, output_path: Path) -> None:
 
 if __name__ == "__main__":
     csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
-    output_dir = Path("artifacts/visualization")
+    output_dir = Path("artifacts/visualization/position_bias")
 
-    plot_all_providers(csv_path, output_dir / "position_bias_all_providers.png")
-    plot_by_provider(csv_path, output_dir / "position_bias_by_provider.png")
+    plot_all_providers(csv_path, output_dir / "all_providers.png")
+    plot_by_provider(csv_path, output_dir / "by_provider.png")

--- a/experiments/visualization/choice_model_position_bias.py
+++ b/experiments/visualization/choice_model_position_bias.py
@@ -1,0 +1,218 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+import numpy as np
+import pandas as pd
+
+from experiments.visualization.common import (
+    MODEL_METADATA,
+    PROVIDER_COLORS,
+    PROVIDER_COLORS_LIGHT,
+    PROVIDER_COLORS_DARK,
+    apply_clean_style,
+    draw_rounded_bar,
+    add_value_label,
+    create_modern_legend,
+)
+
+POSITION_LABELS = ["1", "2", "3", "4", "5", "6", "7", "8"]
+
+
+def load_choice_model_data(csv_path: Path) -> pd.DataFrame:
+    return pd.read_csv(csv_path, index_col=0)
+
+
+def compute_position_probabilities(df: pd.DataFrame) -> dict[str, np.ndarray]:
+    """Compute softmax selection probabilities for each of the 8 grid positions per model."""
+    results = {}
+    for model_id in df.columns:
+        row1 = df.loc["row_1_dummy", model_id]
+        col1 = df.loc["col_1_dummy", model_id]
+        col2 = df.loc["col_2_dummy", model_id]
+        col3 = df.loc["col_3_dummy", model_id]
+
+        coeffs = np.array([
+            row1 + col1,  # Position 1: R1C1
+            row1 + col2,  # Position 2: R1C2
+            row1 + col3,  # Position 3: R1C3
+            row1,         # Position 4: R1C4 (col4 = 0)
+            col1,         # Position 5: R2C1 (row2 = 0)
+            col2,         # Position 6: R2C2
+            col3,         # Position 7: R2C3
+            0.0,          # Position 8: R2C4 (both baselines)
+        ])
+
+        exp_coeffs = np.exp(coeffs - np.max(coeffs))
+        probs = exp_coeffs / exp_coeffs.sum()
+        results[model_id] = probs
+
+    return results
+
+
+def _sort_models_by_date(model_ids: list[str]) -> list[str]:
+    return sorted(model_ids, key=lambda m: MODEL_METADATA[m][1])
+
+
+def _draw_grouped_bars(
+    ax: plt.Axes,
+    model_ids: list[str],
+    probs: dict[str, np.ndarray],
+    show_position_labels: bool = True,
+    show_values: bool = True,
+) -> float:
+    n_models = len(model_ids)
+    n_positions = 8
+    bar_width = 0.08
+    group_width = n_positions * bar_width
+    group_gap = 0.25
+    x = np.arange(n_models) * (group_width + group_gap)
+
+    rounding = 0.012
+    all_heights = []
+    for model_idx, model_id in enumerate(model_ids):
+        provider = MODEL_METADATA[model_id][2]
+        color = PROVIDER_COLORS[provider]
+        light_color = PROVIDER_COLORS_LIGHT[provider]
+        max_pos = int(np.argmax(probs[model_id]))
+
+        for pos_idx in range(n_positions):
+            bx = x[model_idx] + pos_idx * bar_width
+            height = probs[model_id][pos_idx]
+            all_heights.append(height)
+
+            # Only draw bar if height is non-zero (skip tiny/zero bars)
+            if height > 0.001:  # Threshold for ~0.1%
+                # Highlight the maximum position
+                is_max = (pos_idx == max_pos)
+                fill = color + "30" if is_max else "white"
+
+                draw_rounded_bar(
+                    ax, bx, height, bar_width, color,
+                    fill=fill,
+                    rounding=rounding,
+                )
+
+            # Add value labels for all bars (lighter color for less density)
+            if show_values:
+                add_value_label(
+                    ax, bx, height, height,
+                    color="#AAAAAA",  # Lighter gray for all labels
+                    fontsize=6,
+                    offset_y=0.003,
+                    rotation=90,
+                )
+
+    x_max = x[-1] + (n_positions - 1) * bar_width + bar_width
+    ax.set_xlim(x[0] - bar_width, x_max)
+    max_h = max(all_heights) if all_heights else 0.125
+
+    if show_position_labels:
+        for model_idx in range(n_models):
+            for pos_idx in range(n_positions):
+                bx = x[model_idx] + pos_idx * bar_width
+                ax.text(
+                    bx, -0.015, POSITION_LABELS[pos_idx],
+                    ha="center", va="top", fontsize=6.5, color="#999999",
+                    fontweight="medium",
+                )
+
+    centers = x + (n_positions - 1) * bar_width / 2
+    display_names = [MODEL_METADATA[m][0] for m in model_ids]
+    ax.set_xticks(centers)
+    ax.set_xticklabels(display_names, rotation=0, ha="center", fontsize=9)
+    ax.tick_params(axis="x", pad=20)
+
+    # Reference line for uniform distribution
+    ax.axhline(y=1 / 8, color="#999999", linestyle="--", linewidth=1.5, alpha=0.6, zorder=0)
+    ax.text(
+        x[0] - bar_width * 2, 1 / 8, "Uniform\n(12.5%)",
+        ha="right", va="center", fontsize=8, color="#999999",
+        bbox=dict(boxstyle="round,pad=0.4", facecolor="white", edgecolor="#E0E0E0", alpha=0.9),
+    )
+
+    apply_clean_style(ax)
+    ax.set_ylabel("Selection probability", fontsize=11, color="#555555", fontweight="medium")
+
+    return max_h
+
+
+def plot_all_providers(csv_path: Path, output_path: Path) -> None:
+    """All models on one chart, x-labels colored by provider."""
+    df = load_choice_model_data(csv_path)
+    probs = compute_position_probabilities(df)
+    model_ids = _sort_models_by_date([m for m in df.columns if m in MODEL_METADATA])
+
+    fig, ax = plt.subplots(figsize=(16, 5))
+    max_h = _draw_grouped_bars(ax, model_ids, probs)
+    ax.set_ylim(0, max_h * 1.15)
+
+    for tick_label, model_id in zip(ax.get_xticklabels(), model_ids):
+        provider = MODEL_METADATA[model_id][2]
+        tick_label.set_color(PROVIDER_COLORS_DARK[provider])
+        tick_label.set_fontweight("semibold")
+
+    ax.set_title(
+        "Position bias across models (by release date)",
+        fontsize=14, fontweight="bold", color="#222222", pad=16,
+    )
+
+    create_modern_legend(ax, PROVIDER_COLORS, loc="upper right")
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def plot_by_provider(csv_path: Path, output_path: Path) -> None:
+    """One subplot per provider."""
+    df = load_choice_model_data(csv_path)
+    probs = compute_position_probabilities(df)
+
+    providers = ["Anthropic", "Google", "OpenAI"]
+    provider_models = {
+        p: _sort_models_by_date(
+            [m for m in df.columns if m in MODEL_METADATA and MODEL_METADATA[m][2] == p]
+        )
+        for p in providers
+    }
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
+
+    # Collect max heights from all providers to set consistent y-axis
+    max_heights = []
+    for ax, provider in zip(axes, providers):
+        model_ids = provider_models[provider]
+        max_h = _draw_grouped_bars(ax, model_ids, probs, show_values=True)
+        max_heights.append(max_h)
+        ax.set_title(
+            provider, fontsize=13, fontweight="bold",
+            color=PROVIDER_COLORS_DARK[provider], pad=12,
+        )
+
+    # Set consistent y-axis limit across all subplots based on global max
+    global_max = max(max_heights) if max_heights else 0.125
+    axes[0].set_ylim(0, global_max * 1.15)  # sharey=True propagates to all axes
+
+    axes[1].set_ylabel("")
+    axes[2].set_ylabel("")
+
+    fig.suptitle(
+        "Position bias by provider (by release date)",
+        fontsize=15, fontweight="bold", color="#222222", y=1.02,
+    )
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+if __name__ == "__main__":
+    csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
+    output_dir = Path("artifacts/visualization")
+
+    plot_all_providers(csv_path, output_dir / "position_bias_all_providers.png")
+    plot_by_provider(csv_path, output_dir / "position_bias_by_provider.png")

--- a/experiments/visualization/cli.py
+++ b/experiments/visualization/cli.py
@@ -46,6 +46,20 @@ def heatmap(csv_file: Path) -> None:
     typer.echo(f"Heatmap plots generated in {output_dir}/")
 
 
+@app.command("price-tradeoffs")
+def price_tradeoffs(csv_file: Path) -> None:
+    """Generate price-equivalent trade-off visualizations from choice model CSV."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.price_equivalent_tradeoffs import generate_all_price_equivalent_plots
+
+    output_dir = Path("artifacts/visualization/price_equivalent_tradeoffs")
+    generate_all_price_equivalent_plots(csv_file, output_dir)
+    typer.echo(f"Price-equivalent trade-off plots generated in {output_dir}/ (10 plots total)")
+
+
 @sanity_checks_app.callback(invoke_without_command=True)
 def sanity_checks_callback(ctx: typer.Context) -> None:
     """Generate sanity check visualizations."""

--- a/experiments/visualization/cli.py
+++ b/experiments/visualization/cli.py
@@ -61,36 +61,10 @@ def sanity_checks_rating(csv_file: Path) -> None:
         typer.echo(f"Error: File not found: {csv_file}", err=True)
         raise typer.Exit(1)
 
-    from experiments.visualization.sanity_checks import (
-        load_sanity_check_data,
-        plot_single_task_by_provider,
-        plot_category_combined,
-    )
+    from experiments.visualization.sanity_checks import generate_rating_plots
 
     output_dir = Path("artifacts/visualization/sanity_checks")
-    _, tests, data = load_sanity_check_data(csv_file)
-
-    # Individual plots
-    tasks = [
-        (0, "rating_plus_0.1", "Rating +0.1 sanity check failure rates by provider", "+0.1 Rating"),
-        (1, "rating_random_low_variance", "Rating random (low variance) failure rates by provider", "Low Variance"),
-        (2, "rating_random_high_variance", "Rating random (high variance) failure rates by provider", "High Variance"),
-    ]
-
-    for task_idx, filename, title, task_label in tasks:
-        plot_single_task_by_provider(
-            data, task_idx, output_dir / f"{filename}.png",
-            title=title, task_label=task_label
-        )
-
-    # Combined plot
-    plot_category_combined(
-        data,
-        ["+0.1 Rating", "Low Variance", "High Variance"],
-        output_dir / "rating_combined.png",
-        title="Rating sanity checks combined (by release date)",
-    )
-
+    generate_rating_plots(csv_file, output_dir)
     typer.echo(f"Rating sanity check plots generated in {output_dir}/")
 
 
@@ -107,38 +81,10 @@ def sanity_checks_price(
         typer.echo(f"Error: File not found: {ar_price_csv}", err=True)
         raise typer.Exit(1)
 
-    from experiments.visualization.sanity_checks import (
-        load_combined_price_data,
-        plot_single_task_by_provider,
-        plot_category_combined,
-    )
+    from experiments.visualization.sanity_checks import generate_price_plots
 
     output_dir = Path("artifacts/visualization/sanity_checks")
-    _, tests, data = load_combined_price_data(price_csv, ar_price_csv)
-
-    # Individual plots
-    tasks = [
-        (0, "price_random_low_variance", "Price random (low variance) failure rates by provider", "Random (Low Var)"),
-        (1, "price_random_high_variance", "Price random (high variance) failure rates by provider", "Random (High Var)"),
-        (2, "price_1_percent", "Price 1% reduction failure rates by provider", "1% Reduction"),
-        (3, "price_5_percent", "Price 5% reduction failure rates by provider", "5% Reduction"),
-        (4, "price_10_percent", "Price 10% reduction failure rates by provider", "10% Reduction"),
-    ]
-
-    for task_idx, filename, title, task_label in tasks:
-        plot_single_task_by_provider(
-            data, task_idx, output_dir / f"{filename}.png",
-            title=title, task_label=task_label
-        )
-
-    # Combined plot
-    plot_category_combined(
-        data,
-        ["Random (Low Var)", "Random (High Var)", "1% Reduction", "5% Reduction", "10% Reduction"],
-        output_dir / "price_combined.png",
-        title="Price sanity checks combined (by release date)",
-    )
-
+    generate_price_plots(price_csv, ar_price_csv, output_dir)
     typer.echo(f"Price sanity check plots generated in {output_dir}/")
 
 
@@ -149,36 +95,10 @@ def sanity_checks_instruction(csv_file: Path) -> None:
         typer.echo(f"Error: File not found: {csv_file}", err=True)
         raise typer.Exit(1)
 
-    from experiments.visualization.sanity_checks import (
-        load_sanity_check_data,
-        plot_single_task_by_provider,
-        plot_category_combined,
-    )
+    from experiments.visualization.sanity_checks import generate_instruction_plots
 
     output_dir = Path("artifacts/visualization/sanity_checks")
-    _, tests, data = load_sanity_check_data(csv_file)
-
-    # Individual plots
-    tasks = [
-        (0, "instruction_budget", "Instruction following (budget) failure rates by provider", "Budget"),
-        (1, "instruction_color", "Instruction following (color) failure rates by provider", "Color"),
-        (2, "instruction_brand", "Instruction following (brand) failure rates by provider", "Brand"),
-    ]
-
-    for task_idx, filename, title, task_label in tasks:
-        plot_single_task_by_provider(
-            data, task_idx, output_dir / f"{filename}.png",
-            title=title, task_label=task_label
-        )
-
-    # Combined plot
-    plot_category_combined(
-        data,
-        ["Budget", "Color", "Brand"],
-        output_dir / "instruction_combined.png",
-        title="Instruction following combined (by release date)",
-    )
-
+    generate_instruction_plots(csv_file, output_dir)
     typer.echo(f"Instruction sanity check plots generated in {output_dir}/")
 
 
@@ -190,20 +110,25 @@ def sanity_checks_all(
     instruction_csv: Path,
 ) -> None:
     """Generate all sanity check visualizations."""
-    from typer import Context
+    if not rating_csv.exists():
+        typer.echo(f"Error: File not found: {rating_csv}", err=True)
+        raise typer.Exit(1)
+    if not price_csv.exists():
+        typer.echo(f"Error: File not found: {price_csv}", err=True)
+        raise typer.Exit(1)
+    if not ar_price_csv.exists():
+        typer.echo(f"Error: File not found: {ar_price_csv}", err=True)
+        raise typer.Exit(1)
+    if not instruction_csv.exists():
+        typer.echo(f"Error: File not found: {instruction_csv}", err=True)
+        raise typer.Exit(1)
 
-    ctx = Context(sanity_checks_app)
+    from experiments.visualization.sanity_checks import generate_all_sanity_check_plots
 
-    typer.echo("Generating rating plots...")
-    ctx.invoke(sanity_checks_rating, csv_file=rating_csv)
-
-    typer.echo("\nGenerating price plots...")
-    ctx.invoke(sanity_checks_price, price_csv=price_csv, ar_price_csv=ar_price_csv)
-
-    typer.echo("\nGenerating instruction plots...")
-    ctx.invoke(sanity_checks_instruction, csv_file=instruction_csv)
-
-    typer.echo("\nAll sanity check plots generated!")
+    output_dir = Path("artifacts/visualization/sanity_checks")
+    typer.echo("Generating all sanity check plots...")
+    generate_all_sanity_check_plots(rating_csv, price_csv, ar_price_csv, instruction_csv, output_dir)
+    typer.echo(f"\nAll sanity check plots generated in {output_dir}/")
 
 
 @feature_impact_app.callback(invoke_without_command=True)

--- a/experiments/visualization/cli.py
+++ b/experiments/visualization/cli.py
@@ -155,7 +155,7 @@ def feature_impact_all(csv_file: Path) -> None:
 
 @feature_impact_app.command("rating")
 def feature_impact_rating(csv_file: Path) -> None:
-    """Generate rating feature impact visualizations only."""
+    """Generate rating feature impact visualizations (all_providers + by_provider)."""
     if not csv_file.exists():
         typer.echo(f"Error: File not found: {csv_file}", err=True)
         raise typer.Exit(1)
@@ -164,12 +164,12 @@ def feature_impact_rating(csv_file: Path) -> None:
 
     output_dir = Path("artifacts/visualization/feature_impact")
     plot_rating_impact_by_provider(csv_file, output_dir)
-    typer.echo(f"Rating impact plot generated in {output_dir}/")
+    typer.echo(f"Rating impact plots generated in {output_dir}/ (all_providers + by_provider)")
 
 
 @feature_impact_app.command("price")
 def feature_impact_price(csv_file: Path) -> None:
-    """Generate price feature impact visualizations only."""
+    """Generate price feature impact visualizations (all_providers + by_provider)."""
     if not csv_file.exists():
         typer.echo(f"Error: File not found: {csv_file}", err=True)
         raise typer.Exit(1)
@@ -178,12 +178,12 @@ def feature_impact_price(csv_file: Path) -> None:
 
     output_dir = Path("artifacts/visualization/feature_impact")
     plot_price_impact_by_provider(csv_file, output_dir)
-    typer.echo(f"Price impact plot generated in {output_dir}/")
+    typer.echo(f"Price impact plots generated in {output_dir}/ (all_providers + by_provider)")
 
 
 @feature_impact_app.command("tags")
 def feature_impact_tags(csv_file: Path) -> None:
-    """Generate tags feature impact visualizations only."""
+    """Generate tags feature impact visualizations (all_providers + by_provider for both tags)."""
     if not csv_file.exists():
         typer.echo(f"Error: File not found: {csv_file}", err=True)
         raise typer.Exit(1)
@@ -192,7 +192,7 @@ def feature_impact_tags(csv_file: Path) -> None:
 
     output_dir = Path("artifacts/visualization/feature_impact")
     plot_tags_impact_by_provider(csv_file, output_dir)
-    typer.echo(f"Tags impact plot generated in {output_dir}/")
+    typer.echo(f"Tags impact plots generated in {output_dir}/ (4 plots: all_providers + by_provider for sponsored tag and overall pick)")
 
 
 if __name__ == "__main__":

--- a/experiments/visualization/cli.py
+++ b/experiments/visualization/cli.py
@@ -1,0 +1,274 @@
+from pathlib import Path
+
+import typer
+
+app = typer.Typer()
+sanity_checks_app = typer.Typer()
+feature_impact_app = typer.Typer()
+app.add_typer(sanity_checks_app, name="sanity-checks", help="Generate sanity check visualizations")
+app.add_typer(feature_impact_app, name="feature-impact", help="Generate feature impact visualizations")
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    """Visualization CLI for generating plots from analysis results."""
+    if ctx.invoked_subcommand is None:
+        print(ctx.get_help())
+        raise typer.Exit(0)
+
+
+@app.command("position-bias")
+def position_bias(csv_file: Path) -> None:
+    """Generate position bias visualizations from choice model CSV."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.choice_model_position_bias import plot_all_providers, plot_by_provider
+
+    output_dir = Path("artifacts/visualization/position_bias")
+    plot_all_providers(csv_file, output_dir / "all_providers.png")
+    plot_by_provider(csv_file, output_dir / "by_provider.png")
+    typer.echo(f"Position bias plots generated in {output_dir}/")
+
+
+@app.command("heatmap")
+def heatmap(csv_file: Path) -> None:
+    """Generate position probability heatmaps from choice model CSV."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.heatmaps import generate_all_heatmaps
+
+    output_dir = Path("artifacts/visualization/heatmaps")
+    generate_all_heatmaps(csv_file, output_dir)
+    typer.echo(f"Heatmap plots generated in {output_dir}/")
+
+
+@sanity_checks_app.callback(invoke_without_command=True)
+def sanity_checks_callback(ctx: typer.Context) -> None:
+    """Generate sanity check visualizations."""
+    if ctx.invoked_subcommand is None:
+        print(ctx.get_help())
+        raise typer.Exit(0)
+
+
+@sanity_checks_app.command("rating")
+def sanity_checks_rating(csv_file: Path) -> None:
+    """Generate rating sanity check visualizations."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.sanity_checks import (
+        load_sanity_check_data,
+        plot_single_task_by_provider,
+        plot_category_combined,
+    )
+
+    output_dir = Path("artifacts/visualization/sanity_checks")
+    _, tests, data = load_sanity_check_data(csv_file)
+
+    # Individual plots
+    tasks = [
+        (0, "rating_plus_0.1", "Rating +0.1 sanity check failure rates by provider", "+0.1 Rating"),
+        (1, "rating_random_low_variance", "Rating random (low variance) failure rates by provider", "Low Variance"),
+        (2, "rating_random_high_variance", "Rating random (high variance) failure rates by provider", "High Variance"),
+    ]
+
+    for task_idx, filename, title, task_label in tasks:
+        plot_single_task_by_provider(
+            data, task_idx, output_dir / f"{filename}.png",
+            title=title, task_label=task_label
+        )
+
+    # Combined plot
+    plot_category_combined(
+        data,
+        ["+0.1 Rating", "Low Variance", "High Variance"],
+        output_dir / "rating_combined.png",
+        title="Rating sanity checks combined (by release date)",
+    )
+
+    typer.echo(f"Rating sanity check plots generated in {output_dir}/")
+
+
+@sanity_checks_app.command("price")
+def sanity_checks_price(
+    price_csv: Path,
+    ar_price_csv: Path,
+) -> None:
+    """Generate price sanity check visualizations (combines price and ar_price data)."""
+    if not price_csv.exists():
+        typer.echo(f"Error: File not found: {price_csv}", err=True)
+        raise typer.Exit(1)
+    if not ar_price_csv.exists():
+        typer.echo(f"Error: File not found: {ar_price_csv}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.sanity_checks import (
+        load_combined_price_data,
+        plot_single_task_by_provider,
+        plot_category_combined,
+    )
+
+    output_dir = Path("artifacts/visualization/sanity_checks")
+    _, tests, data = load_combined_price_data(price_csv, ar_price_csv)
+
+    # Individual plots
+    tasks = [
+        (0, "price_random_low_variance", "Price random (low variance) failure rates by provider", "Random (Low Var)"),
+        (1, "price_random_high_variance", "Price random (high variance) failure rates by provider", "Random (High Var)"),
+        (2, "price_1_percent", "Price 1% reduction failure rates by provider", "1% Reduction"),
+        (3, "price_5_percent", "Price 5% reduction failure rates by provider", "5% Reduction"),
+        (4, "price_10_percent", "Price 10% reduction failure rates by provider", "10% Reduction"),
+    ]
+
+    for task_idx, filename, title, task_label in tasks:
+        plot_single_task_by_provider(
+            data, task_idx, output_dir / f"{filename}.png",
+            title=title, task_label=task_label
+        )
+
+    # Combined plot
+    plot_category_combined(
+        data,
+        ["Random (Low Var)", "Random (High Var)", "1% Reduction", "5% Reduction", "10% Reduction"],
+        output_dir / "price_combined.png",
+        title="Price sanity checks combined (by release date)",
+    )
+
+    typer.echo(f"Price sanity check plots generated in {output_dir}/")
+
+
+@sanity_checks_app.command("instruction")
+def sanity_checks_instruction(csv_file: Path) -> None:
+    """Generate instruction following sanity check visualizations."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.sanity_checks import (
+        load_sanity_check_data,
+        plot_single_task_by_provider,
+        plot_category_combined,
+    )
+
+    output_dir = Path("artifacts/visualization/sanity_checks")
+    _, tests, data = load_sanity_check_data(csv_file)
+
+    # Individual plots
+    tasks = [
+        (0, "instruction_budget", "Instruction following (budget) failure rates by provider", "Budget"),
+        (1, "instruction_color", "Instruction following (color) failure rates by provider", "Color"),
+        (2, "instruction_brand", "Instruction following (brand) failure rates by provider", "Brand"),
+    ]
+
+    for task_idx, filename, title, task_label in tasks:
+        plot_single_task_by_provider(
+            data, task_idx, output_dir / f"{filename}.png",
+            title=title, task_label=task_label
+        )
+
+    # Combined plot
+    plot_category_combined(
+        data,
+        ["Budget", "Color", "Brand"],
+        output_dir / "instruction_combined.png",
+        title="Instruction following combined (by release date)",
+    )
+
+    typer.echo(f"Instruction sanity check plots generated in {output_dir}/")
+
+
+@sanity_checks_app.command("all")
+def sanity_checks_all(
+    rating_csv: Path,
+    price_csv: Path,
+    ar_price_csv: Path,
+    instruction_csv: Path,
+) -> None:
+    """Generate all sanity check visualizations."""
+    from typer import Context
+
+    ctx = Context(sanity_checks_app)
+
+    typer.echo("Generating rating plots...")
+    ctx.invoke(sanity_checks_rating, csv_file=rating_csv)
+
+    typer.echo("\nGenerating price plots...")
+    ctx.invoke(sanity_checks_price, price_csv=price_csv, ar_price_csv=ar_price_csv)
+
+    typer.echo("\nGenerating instruction plots...")
+    ctx.invoke(sanity_checks_instruction, csv_file=instruction_csv)
+
+    typer.echo("\nAll sanity check plots generated!")
+
+
+@feature_impact_app.callback(invoke_without_command=True)
+def feature_impact_callback(ctx: typer.Context) -> None:
+    """Generate feature impact visualizations."""
+    if ctx.invoked_subcommand is None:
+        print(ctx.get_help())
+        raise typer.Exit(0)
+
+
+@feature_impact_app.command("all")
+def feature_impact_all(csv_file: Path) -> None:
+    """Generate all feature impact visualizations."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.feature_impact import generate_all_feature_impact_plots
+
+    output_dir = Path("artifacts/visualization/feature_impact")
+    generate_all_feature_impact_plots(csv_file, output_dir)
+    typer.echo(f"Feature impact plots generated in {output_dir}/")
+
+
+@feature_impact_app.command("rating")
+def feature_impact_rating(csv_file: Path) -> None:
+    """Generate rating feature impact visualizations only."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.feature_impact import plot_rating_impact_by_provider
+
+    output_dir = Path("artifacts/visualization/feature_impact")
+    plot_rating_impact_by_provider(csv_file, output_dir)
+    typer.echo(f"Rating impact plot generated in {output_dir}/")
+
+
+@feature_impact_app.command("price")
+def feature_impact_price(csv_file: Path) -> None:
+    """Generate price feature impact visualizations only."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.feature_impact import plot_price_impact_by_provider
+
+    output_dir = Path("artifacts/visualization/feature_impact")
+    plot_price_impact_by_provider(csv_file, output_dir)
+    typer.echo(f"Price impact plot generated in {output_dir}/")
+
+
+@feature_impact_app.command("tags")
+def feature_impact_tags(csv_file: Path) -> None:
+    """Generate tags feature impact visualizations only."""
+    if not csv_file.exists():
+        typer.echo(f"Error: File not found: {csv_file}", err=True)
+        raise typer.Exit(1)
+
+    from experiments.visualization.feature_impact import plot_tags_impact_by_provider
+
+    output_dir = Path("artifacts/visualization/feature_impact")
+    plot_tags_impact_by_provider(csv_file, output_dir)
+    typer.echo(f"Tags impact plot generated in {output_dir}/")
+
+
+if __name__ == "__main__":
+    app()

--- a/experiments/visualization/common.py
+++ b/experiments/visualization/common.py
@@ -99,6 +99,7 @@ def draw_rounded_bar(
     color: str,
     fill: str = "white",
     rounding: float = 0.012,
+    hatch: str | None = "///",
 ) -> None:
     """Draw a bar with hatched pattern, rounded only on top."""
     from matplotlib.patches import Rectangle
@@ -118,7 +119,7 @@ def draw_rounded_bar(
         facecolor=fill,
         edgecolor=color,
         linewidth=1.0,
-        hatch="///",
+        hatch=hatch,
     )
     ax.add_patch(rect)
 

--- a/experiments/visualization/common.py
+++ b/experiments/visualization/common.py
@@ -1,0 +1,185 @@
+from datetime import date
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+from matplotlib.patches import FancyBboxPatch, Rectangle
+from matplotlib.colors import LinearSegmentedColormap
+import numpy as np
+
+# Modern, accessible font and styling
+mpl.rcParams.update({
+    "font.family": "sans-serif",
+    "font.sans-serif": ["SF Pro Display", "Segoe UI", "Helvetica Neue", "Arial"],
+    "font.size": 11,
+    "axes.titlesize": 14,
+    "axes.labelsize": 12,
+    "xtick.labelsize": 10,
+    "ytick.labelsize": 10,
+    "figure.dpi": 150,
+    "axes.facecolor": "#FAFAFA",
+    "figure.facecolor": "white",
+})
+
+# (display_name, release_date, provider)
+MODEL_METADATA = {
+    "gpt-4o-2024-11-20": ("GPT-4o", date(2024, 11, 20), "OpenAI"),
+    "gemini-2.0-flash-001": ("Gemini 2.0 Flash", date(2025, 2, 5), "Google"),
+    "claude-opus-4-20250514": ("Claude Opus 4", date(2025, 5, 22), "Anthropic"),
+    "gemini-2.5-pro": ("Gemini 2.5 Pro", date(2025, 6, 17), "Google"),
+    "claude-opus-4-1-20250805": ("Claude Opus 4.1", date(2025, 8, 5), "Anthropic"),
+    "gpt-5": ("GPT-5", date(2025, 8, 7), "OpenAI"),
+    "claude-sonnet-4-5-20250929": ("Claude Sonnet 4.5", date(2025, 9, 29), "Anthropic"),
+    "claude-opus-4-5-20251101": ("Claude Opus 4.5", date(2025, 11, 24), "Anthropic"),
+    "gpt-5.1": ("GPT-5.1", date(2025, 11, 12), "OpenAI"),
+    "gemini-3-pro-preview": ("Gemini 3 Pro", date(2025, 11, 18), "Google"),
+    "gemini-3-flash-preview": ("Gemini 3 Flash", date(2025, 12, 17), "Google"),
+    "gpt-5.2": ("GPT-5.2", date(2025, 12, 11), "OpenAI"),
+}
+
+# display name → (model_id, release_date, provider)
+DISPLAY_NAME_TO_METADATA = {
+    v[0]: (k, v[1], v[2]) for k, v in MODEL_METADATA.items()
+}
+# also handle slight naming differences in sanity check CSVs
+DISPLAY_NAME_TO_METADATA["Gemini 3 Flash Preview"] = DISPLAY_NAME_TO_METADATA["Gemini 3 Flash"]
+DISPLAY_NAME_TO_METADATA["Gemini 3 Pro Preview"] = DISPLAY_NAME_TO_METADATA["Gemini 3 Pro"]
+
+PROVIDER_COLORS = {
+    "Anthropic": "#D97757",  # Warm coral-orange (official brand color)
+    "Google": "#4285F4",     # Google blue (official brand color)
+    "OpenAI": "#000000",     # Black (official brand color)
+}
+
+# Lighter variants for gradients and highlights
+PROVIDER_COLORS_LIGHT = {
+    "Anthropic": "#F4B8A0",
+    "Google": "#8AB4F8",
+    "OpenAI": "#666666",  # Gray for lighter variant
+}
+
+# Darker variants for emphasis
+PROVIDER_COLORS_DARK = {
+    "Anthropic": "#B85A3A",
+    "Google": "#1967D2",
+    "OpenAI": "#000000",  # Black stays black
+}
+
+
+def apply_clean_style(ax: plt.Axes, use_percent: bool = True) -> None:
+    """Apply modern, clean styling to axes."""
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_color("#E0E0E0")
+    ax.spines["left"].set_linewidth(1.5)
+    ax.spines["bottom"].set_color("#E0E0E0")
+    ax.spines["bottom"].set_linewidth(1.5)
+    ax.tick_params(colors="#666666", labelsize=10, width=1.2)
+    if use_percent:
+        ax.yaxis.set_major_formatter(mticker.PercentFormatter(xmax=1.0))
+    ax.set_axisbelow(True)
+    ax.yaxis.grid(True, color="#E8E8E8", linewidth=1.0, linestyle="-", alpha=0.7)
+    ax.xaxis.grid(False)
+    ax.set_facecolor("#FAFAFA")
+
+
+def sort_display_names_by_date(names: list[str]) -> list[str]:
+    return sorted(names, key=lambda n: DISPLAY_NAME_TO_METADATA[n][1])
+
+
+def get_provider_for_display_name(name: str) -> str:
+    return DISPLAY_NAME_TO_METADATA[name][2]
+
+
+def draw_rounded_bar(
+    ax: plt.Axes,
+    x: float,
+    height: float,
+    width: float,
+    color: str,
+    fill: str = "white",
+    rounding: float = 0.012,
+) -> None:
+    """Draw a bar with hatched pattern, rounded only on top."""
+    from matplotlib.patches import Rectangle
+    from matplotlib.path import Path
+    from matplotlib.patches import PathPatch
+
+    x_left = x - width / 2
+    x_right = x + width / 2
+    corner_radius = rounding * 10  # Convert to absolute size
+
+    # Use simple rectangle with rounded top if matplotlib supports it
+    # Otherwise, just use FancyBboxPatch with custom style
+    rect = FancyBboxPatch(
+        (x_left, 0),
+        width, height,
+        boxstyle=f"round,pad=0,rounding_size={rounding}",
+        facecolor=fill,
+        edgecolor=color,
+        linewidth=1.0,
+        hatch="///",
+    )
+    ax.add_patch(rect)
+
+
+def add_value_label(
+    ax: plt.Axes,
+    x: float,
+    y: float,
+    value: float,
+    color: str = "#333333",
+    fontsize: int = 8,
+    format_str: str = "{:.1%}",
+    offset_y: float = 0.005,
+    rotation: int = 0,
+    skip_zero: bool = True,
+) -> None:
+    """Add a value label above a bar."""
+    threshold = 0.001 if skip_zero else -1  # Skip values less than 0.1% if skip_zero is True
+    if not np.isnan(value) and value > threshold:
+        ax.text(
+            x, y + offset_y,
+            format_str.format(value),
+            ha="center", va="bottom",
+            fontsize=fontsize, color=color,
+            fontweight="medium",
+            rotation=rotation,
+        )
+
+
+def create_modern_legend(
+    ax: plt.Axes,
+    provider_colors: dict,
+    title: str = "Provider",
+    loc: str = "upper right",
+) -> None:
+    """Create a modern, clean legend."""
+    from matplotlib.patches import Patch
+
+    handles = [
+        Patch(
+            facecolor=provider_colors[p],
+            edgecolor=PROVIDER_COLORS_DARK.get(p, provider_colors[p]),
+            linewidth=1.5,
+            label=p,
+            alpha=0.8,
+        )
+        for p in provider_colors
+    ]
+    legend = ax.legend(
+        handles=handles,
+        title=title,
+        loc=loc,
+        fontsize=9,
+        title_fontsize=10,
+        frameon=True,
+        fancybox=False,
+        edgecolor="#D0D0D0",
+        framealpha=0.95,
+        borderpad=0.8,
+        labelspacing=0.6,
+    )
+    legend.get_frame().set_facecolor("white")
+    legend.get_title().set_fontweight("semibold")
+    legend.get_title().set_color("#333333")

--- a/experiments/visualization/feature_impact.py
+++ b/experiments/visualization/feature_impact.py
@@ -1,0 +1,486 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from experiments.visualization.common import (
+    MODEL_METADATA,
+    PROVIDER_COLORS,
+    PROVIDER_COLORS_DARK,
+    PROVIDER_COLORS_LIGHT,
+    apply_clean_style,
+    create_modern_legend,
+    draw_rounded_bar,
+)
+
+
+def load_choice_model_coefficients(csv_path: Path) -> pd.DataFrame:
+    """Load choice model coefficients."""
+    return pd.read_csv(csv_path, index_col=0)
+
+
+def compute_probability_change(
+    baseline_prob: float,
+    coefficient: float,
+    n_alternatives: int = 8,
+) -> float:
+    """
+    Compute new selection probability after adding a feature.
+
+    Args:
+        baseline_prob: Baseline selection probability (e.g., 0.1 for 10%)
+        coefficient: Choice model coefficient for the feature
+        n_alternatives: Number of alternatives in choice set (default 8)
+
+    Returns:
+        New selection probability after adding the feature
+    """
+    # Assuming other products have equal probability
+    other_prob = (1 - baseline_prob) / (n_alternatives - 1)
+
+    # Compute baseline utility difference (product vs average other)
+    # baseline_prob = exp(U0) / (exp(U0) + (n-1)*exp(U_other))
+    # Rearranging: exp(U0 - U_other) = baseline_prob / other_prob
+    baseline_utility_diff = np.log(baseline_prob / other_prob)
+
+    # New utility difference after adding feature
+    new_utility_diff = baseline_utility_diff + coefficient
+
+    # Convert back to probability
+    # p_new = exp(U_new) / (exp(U_new) + (n-1)*exp(U_other))
+    # p_new = exp(U_new - U_other) / (exp(U_new - U_other) + (n-1))
+    new_prob = np.exp(new_utility_diff) / (np.exp(new_utility_diff) + (n_alternatives - 1))
+
+    return new_prob
+
+
+def compute_price_impact(
+    baseline_prob: float,
+    price_coefficient: float,
+    price_percentage_change: float,
+    n_alternatives: int = 8,
+) -> float:
+    """
+    Compute new selection probability after changing price by a percentage.
+
+    Args:
+        baseline_prob: Baseline selection probability
+        price_coefficient: Choice model coefficient for log_price
+        price_percentage_change: Percentage change in price (e.g., -0.05 for -5%)
+        n_alternatives: Number of alternatives in choice set
+
+    Returns:
+        New selection probability after price change
+    """
+    # Utility change from percentage price change
+    # new_price = old_price * (1 + price_percentage_change)
+    # utility_change = coefficient * log(new_price / old_price)
+    #                = coefficient * log(1 + price_percentage_change)
+    utility_change = price_coefficient * np.log(1 + price_percentage_change)
+
+    other_prob = (1 - baseline_prob) / (n_alternatives - 1)
+    baseline_utility_diff = np.log(baseline_prob / other_prob)
+    new_utility_diff = baseline_utility_diff + utility_change
+    new_prob = np.exp(new_utility_diff) / (np.exp(new_utility_diff) + (n_alternatives - 1))
+
+    return new_prob
+
+
+def compute_rating_impact(
+    baseline_prob: float,
+    rating_coefficient: float,
+    rating_change: float,
+    n_alternatives: int = 8,
+) -> float:
+    """
+    Compute new selection probability after changing rating.
+
+    Args:
+        baseline_prob: Baseline selection probability
+        rating_coefficient: Choice model coefficient for rating
+        rating_change: Change in rating (e.g., 0.1)
+        n_alternatives: Number of alternatives in choice set
+
+    Returns:
+        New selection probability after rating change
+    """
+    utility_change = rating_coefficient * rating_change
+
+    other_prob = (1 - baseline_prob) / (n_alternatives - 1)
+    baseline_utility_diff = np.log(baseline_prob / other_prob)
+    new_utility_diff = baseline_utility_diff + utility_change
+    new_prob = np.exp(new_utility_diff) / (np.exp(new_utility_diff) + (n_alternatives - 1))
+
+    return new_prob
+
+
+def _sort_models_by_date(model_ids: list[str]) -> list[str]:
+    """Sort model IDs by release date."""
+    return sorted(model_ids, key=lambda m: MODEL_METADATA[m][1])
+
+
+def plot_feature_impact_all_providers(
+    csv_path: Path,
+    output_path: Path,
+    feature_name: str,
+    coefficient_name: str,
+    rating_change: float | None = None,
+    price_percentage_change: float | None = None,
+    baseline_prob: float = 0.1,
+) -> None:
+    """
+    Plot how selection probability changes for a single feature across all models.
+
+    Shows baseline probability and change for all models, sorted by release date.
+    X-axis labels are colored by provider.
+    """
+    df = load_choice_model_coefficients(csv_path)
+
+    # Get all models that are in MODEL_METADATA
+    model_ids = [m for m in df.columns if m in MODEL_METADATA]
+    model_ids = _sort_models_by_date(model_ids)
+
+    n_models = len(model_ids)
+
+    fig, ax = plt.subplots(figsize=(16, 5))
+
+    bar_width = 0.65
+    x = np.arange(n_models)
+
+    # Compute probabilities for all models
+    probabilities = []
+    changes = []
+
+    for model_id in model_ids:
+        if rating_change is not None:
+            # Rating change
+            new_prob = compute_rating_impact(
+                baseline_prob,
+                df.loc[coefficient_name, model_id],
+                rating_change,
+            )
+        elif price_percentage_change is not None:
+            # Price percentage change
+            new_prob = compute_price_impact(
+                baseline_prob,
+                df.loc[coefficient_name, model_id],
+                price_percentage_change,
+            )
+        else:
+            # Tag addition (binary feature)
+            new_prob = compute_probability_change(
+                baseline_prob,
+                df.loc[coefficient_name, model_id],
+            )
+
+        probabilities.append(new_prob)
+        changes.append(new_prob - baseline_prob)
+
+    # Plot bars for each model
+    for model_idx, (model_id, prob, change) in enumerate(zip(model_ids, probabilities, changes)):
+        provider = MODEL_METADATA[model_id][2]
+        color = PROVIDER_COLORS[provider]
+        bx = x[model_idx]
+
+        # Draw bar to actual probability height (can be above or below baseline)
+        # If change is positive, use light fill; otherwise white
+        if change > 0:
+            fill = PROVIDER_COLORS_LIGHT[provider] + "40"  # Light transparent fill
+        else:
+            fill = "white"
+
+        draw_rounded_bar(
+            ax, bx, prob, bar_width, color,
+            fill=fill,
+            rounding=0.012,
+        )
+
+        # Draw baseline indicator line (dashed horizontal line at baseline)
+        baseline_x_left = bx - bar_width / 2
+        baseline_x_right = bx + bar_width / 2
+        ax.plot(
+            [baseline_x_left, baseline_x_right],
+            [baseline_prob, baseline_prob],
+            color="#666666", linewidth=1.5, linestyle="--",
+            alpha=0.7, zorder=10,
+        )
+
+        # Add value label
+        label_y = prob + 0.005 if prob > baseline_prob else prob - 0.005
+        label_va = "bottom" if prob > baseline_prob else "top"
+        ax.text(
+            bx, label_y,
+            f"{prob:.1%}",
+            ha="center", va=label_va,
+            fontsize=8, color="#333333",
+            fontweight="medium",
+        )
+
+        # Add change label (smaller, inside the bar or between baseline and bar)
+        if abs(change) > 0.02:  # Only show if change is significant enough
+            change_label = f"{change*100:+.1f} p.p."
+            # Position the label in the middle of the change (between baseline and new prob)
+            if change > 0:
+                change_y = baseline_prob + change / 2
+            else:
+                change_y = prob + abs(change) / 2
+            ax.text(
+                bx, change_y,
+                change_label,
+                ha="center", va="center",
+                fontsize=7, color="#333333",
+                fontweight="bold",
+                bbox=dict(boxstyle="round,pad=0.3", facecolor="white", edgecolor="#DDDDDD", alpha=0.95),
+            )
+
+    # Baseline reference line
+    ax.axhline(y=baseline_prob, color="#666666", linestyle="--", linewidth=1.5, alpha=0.5, zorder=0)
+    ax.text(
+        -0.5, baseline_prob, f"Baseline\n({baseline_prob:.0%})",
+        ha="right", va="center", fontsize=8, color="#666666",
+    )
+
+    # Set x-ticks and labels (model names with dates, colored by provider)
+    labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %Y')}" for m in model_ids]
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
+    ax.tick_params(axis="x", pad=10)
+
+    # Color x-tick labels by provider
+    for tick_label, model_id in zip(ax.get_xticklabels(), model_ids):
+        provider = MODEL_METADATA[model_id][2]
+        tick_label.set_color(PROVIDER_COLORS_DARK[provider])
+        tick_label.set_fontweight("semibold")
+
+    # Set axis limits (account for labels above/below bars)
+    max_prob = max(probabilities + [baseline_prob]) + 0.02
+    min_prob = 0  # Keep y-axis starting at 0
+    ax.set_xlim(x[0] - bar_width, x[-1] + bar_width)
+    ax.set_ylim(min_prob, max_prob * 1.1)
+
+    apply_clean_style(ax)
+    ax.set_ylabel("Selection probability", fontsize=11, color="#555555", fontweight="medium")
+
+    # Create title with feature name
+    title = f"Impact of {feature_name} on selection probability (by release date)"
+    ax.set_title(title, fontsize=14, fontweight="bold", color="#222222", pad=16)
+
+    # Provider legend
+    create_modern_legend(ax, PROVIDER_COLORS, loc="upper right")
+
+    # Add note about assumptions
+    note_text = f"Baseline: {baseline_prob:.0%} selection | Gray = baseline, Color = change from {feature_name}"
+    fig.text(
+        0.5, -0.02, note_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def plot_feature_impact_by_provider(
+    csv_path: Path,
+    output_path: Path,
+    feature_name: str,
+    coefficient_name: str,
+    rating_change: float | None = None,
+    price_percentage_change: float | None = None,
+    baseline_prob: float = 0.1,
+) -> None:
+    """
+    Plot how selection probability changes for a single feature by provider.
+
+    Creates 3 subplots (one per provider) showing models sorted by release date.
+    """
+    df = load_choice_model_coefficients(csv_path)
+
+    # Get all models and group by provider
+    all_model_ids = [m for m in df.columns if m in MODEL_METADATA]
+    providers = ["Anthropic", "Google", "OpenAI"]
+    provider_models = {
+        p: _sort_models_by_date(
+            [m for m in all_model_ids if MODEL_METADATA[m][2] == p]
+        )
+        for p in providers
+    }
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
+
+    max_probs_all = []
+
+    for ax, provider in zip(axes, providers):
+        model_ids = provider_models[provider]
+        if not model_ids:
+            continue
+
+        n_models = len(model_ids)
+        bar_width = 0.65
+        x = np.arange(n_models)
+
+        # Compute probabilities
+        probabilities = []
+        changes = []
+
+        for model_id in model_ids:
+            if rating_change is not None:
+                new_prob = compute_rating_impact(
+                    baseline_prob,
+                    df.loc[coefficient_name, model_id],
+                    rating_change,
+                )
+            elif price_percentage_change is not None:
+                new_prob = compute_price_impact(
+                    baseline_prob,
+                    df.loc[coefficient_name, model_id],
+                    price_percentage_change,
+                )
+            else:
+                new_prob = compute_probability_change(
+                    baseline_prob,
+                    df.loc[coefficient_name, model_id],
+                )
+
+            probabilities.append(new_prob)
+            changes.append(new_prob - baseline_prob)
+
+        max_probs_all.extend(probabilities)
+
+        # Plot bars
+        color = PROVIDER_COLORS[provider]
+        for model_idx, (model_id, prob, change) in enumerate(zip(model_ids, probabilities, changes)):
+            bx = x[model_idx]
+
+            # Draw bar to actual probability height (can be above or below baseline)
+            if change > 0:
+                fill = PROVIDER_COLORS_LIGHT[provider] + "40"
+            else:
+                fill = "white"
+
+            draw_rounded_bar(
+                ax, bx, prob, bar_width, color,
+                fill=fill,
+                rounding=0.012,
+            )
+
+            # Draw baseline indicator line
+            baseline_x_left = bx - bar_width / 2
+            baseline_x_right = bx + bar_width / 2
+            ax.plot(
+                [baseline_x_left, baseline_x_right],
+                [baseline_prob, baseline_prob],
+                color="#666666", linewidth=1.5, linestyle="--",
+                alpha=0.7, zorder=10,
+            )
+
+            # Add value label
+            label_y = prob + 0.005 if prob > baseline_prob else prob - 0.005
+            label_va = "bottom" if prob > baseline_prob else "top"
+            ax.text(
+                bx, label_y,
+                f"{prob:.1%}",
+                ha="center", va=label_va,
+                fontsize=8, color="#333333",
+                fontweight="medium",
+            )
+
+            # Add change label
+            if abs(change) > 0.02:
+                change_label = f"{change*100:+.1f} p.p."
+                # Position the label in the middle of the change
+                if change > 0:
+                    change_y = baseline_prob + change / 2
+                else:
+                    change_y = prob + abs(change) / 2
+                ax.text(
+                    bx, change_y,
+                    change_label,
+                    ha="center", va="center",
+                    fontsize=7, color="#333333",
+                    fontweight="bold",
+                    bbox=dict(boxstyle="round,pad=0.3", facecolor="white", edgecolor="#DDDDDD", alpha=0.95),
+                )
+
+        # Set x-ticks and labels (model names with dates)
+        labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %Y')}" for m in model_ids]
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
+        ax.tick_params(axis="x", pad=10)
+
+        # Set axis limits
+        ax.set_xlim(x[0] - bar_width, x[-1] + bar_width)
+
+        apply_clean_style(ax)
+        ax.set_title(
+            provider, fontsize=13, fontweight="bold",
+            color=PROVIDER_COLORS_DARK[provider], pad=12,
+        )
+
+    # Set consistent y-axis for all subplots (account for labels)
+    max_prob = max(max_probs_all + [baseline_prob]) + 0.02
+    axes[0].set_ylim(0, max_prob * 1.1)
+
+    # Reference line for baseline
+    for ax in axes:
+        ax.axhline(y=baseline_prob, color="#999999", linestyle=":", linewidth=1.0, alpha=0.4, zorder=0)
+
+    axes[0].set_ylabel("Selection probability", fontsize=11, color="#555555", fontweight="medium")
+    axes[1].set_ylabel("")
+    axes[2].set_ylabel("")
+
+    # Main title
+    title = f"Impact of {feature_name} on selection probability by provider (by release date)"
+    fig.suptitle(title, fontsize=15, fontweight="bold", color="#222222", y=1.02)
+
+    # Add note
+    note_text = f"Baseline: {baseline_prob:.0%} | Dashed line = baseline"
+    fig.text(
+        0.5, -0.02, note_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+if __name__ == "__main__":
+    csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
+    output_dir = Path("artifacts/visualization")
+
+    # Generate separate plots for each feature (both all providers and by provider)
+    features = [
+        ("Sponsored Tag", "sponsored_tag", None, None, "sponsored_tag"),
+        ("Overall Pick", "overall_pick_tag", None, None, "overall_pick"),
+        ("Rating +0.1", "rating", 0.1, None, "rating_increase"),
+        ("Price -5%", "log_price", None, -0.05, "price_decrease"),
+    ]
+
+    for feature_name, coefficient_name, rating_change, price_percentage_change, filename in features:
+        # All providers plot
+        plot_feature_impact_all_providers(
+            csv_path,
+            output_dir / f"feature_impact_{filename}_all_providers.png",
+            feature_name=feature_name,
+            coefficient_name=coefficient_name,
+            rating_change=rating_change,
+            price_percentage_change=price_percentage_change,
+            baseline_prob=0.1,
+        )
+
+        # By provider plot
+        plot_feature_impact_by_provider(
+            csv_path,
+            output_dir / f"feature_impact_{filename}_by_provider.png",
+            feature_name=feature_name,
+            coefficient_name=coefficient_name,
+            rating_change=rating_change,
+            price_percentage_change=price_percentage_change,
+            baseline_prob=0.1,
+        )

--- a/experiments/visualization/feature_impact.py
+++ b/experiments/visualization/feature_impact.py
@@ -451,7 +451,15 @@ def plot_feature_impact_by_provider(
 
 
 def plot_rating_impact_by_provider(csv_path: Path, output_dir: Path, baseline_prob: float = 0.1) -> None:
-    """Generate rating impact visualization by provider."""
+    """Generate rating impact visualizations (both all_providers and by_provider)."""
+    plot_feature_impact_all_providers(
+        csv_path,
+        output_dir / "rating_increase_all_providers.png",
+        feature_name="Rating +0.1",
+        coefficient_name="rating",
+        rating_change=0.1,
+        baseline_prob=baseline_prob,
+    )
     plot_feature_impact_by_provider(
         csv_path,
         output_dir / "rating_increase_by_provider.png",
@@ -463,7 +471,15 @@ def plot_rating_impact_by_provider(csv_path: Path, output_dir: Path, baseline_pr
 
 
 def plot_price_impact_by_provider(csv_path: Path, output_dir: Path, baseline_prob: float = 0.1) -> None:
-    """Generate price impact visualization by provider."""
+    """Generate price impact visualizations (both all_providers and by_provider)."""
+    plot_feature_impact_all_providers(
+        csv_path,
+        output_dir / "price_decrease_all_providers.png",
+        feature_name="Price -5%",
+        coefficient_name="log_price",
+        price_percentage_change=-0.05,
+        baseline_prob=baseline_prob,
+    )
     plot_feature_impact_by_provider(
         csv_path,
         output_dir / "price_decrease_by_provider.png",
@@ -475,8 +491,15 @@ def plot_price_impact_by_provider(csv_path: Path, output_dir: Path, baseline_pro
 
 
 def plot_tags_impact_by_provider(csv_path: Path, output_dir: Path, baseline_prob: float = 0.1) -> None:
-    """Generate tags impact visualization by provider."""
-    # Sponsored tag
+    """Generate tags impact visualizations (both all_providers and by_provider for each tag)."""
+    # Sponsored tag - both versions
+    plot_feature_impact_all_providers(
+        csv_path,
+        output_dir / "sponsored_tag_all_providers.png",
+        feature_name="Sponsored Tag",
+        coefficient_name="sponsored_tag",
+        baseline_prob=baseline_prob,
+    )
     plot_feature_impact_by_provider(
         csv_path,
         output_dir / "sponsored_tag_by_provider.png",
@@ -485,7 +508,14 @@ def plot_tags_impact_by_provider(csv_path: Path, output_dir: Path, baseline_prob
         baseline_prob=baseline_prob,
     )
 
-    # Overall pick tag
+    # Overall pick tag - both versions
+    plot_feature_impact_all_providers(
+        csv_path,
+        output_dir / "overall_pick_all_providers.png",
+        feature_name="Overall Pick",
+        coefficient_name="overall_pick_tag",
+        baseline_prob=baseline_prob,
+    )
     plot_feature_impact_by_provider(
         csv_path,
         output_dir / "overall_pick_by_provider.png",

--- a/experiments/visualization/feature_impact.py
+++ b/experiments/visualization/feature_impact.py
@@ -450,11 +450,53 @@ def plot_feature_impact_by_provider(
     print(f"Saved: {output_path}")
 
 
-if __name__ == "__main__":
-    csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
-    output_dir = Path("artifacts/visualization/feature_impact")
+def plot_rating_impact_by_provider(csv_path: Path, output_dir: Path, baseline_prob: float = 0.1) -> None:
+    """Generate rating impact visualization by provider."""
+    plot_feature_impact_by_provider(
+        csv_path,
+        output_dir / "rating_increase_by_provider.png",
+        feature_name="Rating +0.1",
+        coefficient_name="rating",
+        rating_change=0.1,
+        baseline_prob=baseline_prob,
+    )
 
-    # Generate separate plots for each feature (both all providers and by provider)
+
+def plot_price_impact_by_provider(csv_path: Path, output_dir: Path, baseline_prob: float = 0.1) -> None:
+    """Generate price impact visualization by provider."""
+    plot_feature_impact_by_provider(
+        csv_path,
+        output_dir / "price_decrease_by_provider.png",
+        feature_name="Price -5%",
+        coefficient_name="log_price",
+        price_percentage_change=-0.05,
+        baseline_prob=baseline_prob,
+    )
+
+
+def plot_tags_impact_by_provider(csv_path: Path, output_dir: Path, baseline_prob: float = 0.1) -> None:
+    """Generate tags impact visualization by provider."""
+    # Sponsored tag
+    plot_feature_impact_by_provider(
+        csv_path,
+        output_dir / "sponsored_tag_by_provider.png",
+        feature_name="Sponsored Tag",
+        coefficient_name="sponsored_tag",
+        baseline_prob=baseline_prob,
+    )
+
+    # Overall pick tag
+    plot_feature_impact_by_provider(
+        csv_path,
+        output_dir / "overall_pick_by_provider.png",
+        feature_name="Overall Pick",
+        coefficient_name="overall_pick_tag",
+        baseline_prob=baseline_prob,
+    )
+
+
+def generate_all_feature_impact_plots(csv_path: Path, output_dir: Path, baseline_prob: float = 0.1) -> None:
+    """Generate all feature impact plots."""
     features = [
         ("Sponsored Tag", "sponsored_tag", None, None, "sponsored_tag"),
         ("Overall Pick", "overall_pick_tag", None, None, "overall_pick"),
@@ -471,7 +513,7 @@ if __name__ == "__main__":
             coefficient_name=coefficient_name,
             rating_change=rating_change,
             price_percentage_change=price_percentage_change,
-            baseline_prob=0.1,
+            baseline_prob=baseline_prob,
         )
 
         # By provider plot
@@ -482,5 +524,11 @@ if __name__ == "__main__":
             coefficient_name=coefficient_name,
             rating_change=rating_change,
             price_percentage_change=price_percentage_change,
-            baseline_prob=0.1,
+            baseline_prob=baseline_prob,
         )
+
+
+if __name__ == "__main__":
+    csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
+    output_dir = Path("artifacts/visualization/feature_impact")
+    generate_all_feature_impact_plots(csv_path, output_dir)

--- a/experiments/visualization/feature_impact.py
+++ b/experiments/visualization/feature_impact.py
@@ -452,7 +452,7 @@ def plot_feature_impact_by_provider(
 
 if __name__ == "__main__":
     csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
-    output_dir = Path("artifacts/visualization")
+    output_dir = Path("artifacts/visualization/feature_impact")
 
     # Generate separate plots for each feature (both all providers and by provider)
     features = [
@@ -466,7 +466,7 @@ if __name__ == "__main__":
         # All providers plot
         plot_feature_impact_all_providers(
             csv_path,
-            output_dir / f"feature_impact_{filename}_all_providers.png",
+            output_dir / f"{filename}_all_providers.png",
             feature_name=feature_name,
             coefficient_name=coefficient_name,
             rating_change=rating_change,
@@ -477,7 +477,7 @@ if __name__ == "__main__":
         # By provider plot
         plot_feature_impact_by_provider(
             csv_path,
-            output_dir / f"feature_impact_{filename}_by_provider.png",
+            output_dir / f"{filename}_by_provider.png",
             feature_name=feature_name,
             coefficient_name=coefficient_name,
             rating_change=rating_change,

--- a/experiments/visualization/feature_impact.py
+++ b/experiments/visualization/feature_impact.py
@@ -242,7 +242,7 @@ def plot_feature_impact_all_providers(
     )
 
     # Set x-ticks and labels (model names with dates, colored by provider)
-    labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %Y')}" for m in model_ids]
+    labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %d, %Y')}" for m in model_ids]
     ax.set_xticks(x)
     ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
     ax.tick_params(axis="x", pad=10)
@@ -406,7 +406,7 @@ def plot_feature_impact_by_provider(
                 )
 
         # Set x-ticks and labels (model names with dates)
-        labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %Y')}" for m in model_ids]
+        labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %d, %Y')}" for m in model_ids]
         ax.set_xticks(x)
         ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
         ax.tick_params(axis="x", pad=10)

--- a/experiments/visualization/heatmaps.py
+++ b/experiments/visualization/heatmaps.py
@@ -64,7 +64,7 @@ def plot_heatmap(
 
     num_rows, num_cols = probabilities.shape
 
-    fig, ax = plt.subplots(figsize=(10, 5))
+    fig, ax = plt.subplots(figsize=(8, 4))
 
     # Use YlGnBu colormap like the example
     cmap = plt.cm.YlGnBu
@@ -109,24 +109,6 @@ def plot_heatmap(
     ax.set_xlim(-gap_x/2, num_cols * (box_width + gap_x))
     ax.set_ylim(-gap_y/2, num_rows * (box_height + gap_y))
     ax.axis('off')
-
-    # Add colorbar if requested
-    if not hide_colorbar:
-        cbar = fig.colorbar(
-            plt.cm.ScalarMappable(norm=norm, cmap=cmap),
-            ax=ax, orientation='vertical', pad=0.02, shrink=0.7
-        )
-        cbar.set_label('Selection Probability', fontsize=18)
-        cbar.set_ticks(np.linspace(vmin, vmax, 5))
-        cbar.set_ticklabels([f'{val:.0%}' for val in np.linspace(vmin, vmax, 5)])
-        cbar.ax.tick_params(labelsize=14)
-
-    # Add title with model name in provider color
-    fig.text(
-        0.5, 0.95, display_name,
-        ha='center', fontsize=20, fontweight='bold',
-        color=PROVIDER_COLORS_DARK[provider]
-    )
 
     plt.tight_layout()
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -181,7 +163,7 @@ def generate_all_heatmaps(csv_path: Path, output_dir: Path) -> None:
             output_path=output_path,
             vmin=vmin,
             vmax=vmax,
-            hide_colorbar=False,  # Show colorbar for reference
+            hide_colorbar=True,
         )
 
 

--- a/experiments/visualization/heatmaps.py
+++ b/experiments/visualization/heatmaps.py
@@ -1,0 +1,192 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import numpy as np
+import pandas as pd
+
+from experiments.visualization.common import (
+    MODEL_METADATA,
+    PROVIDER_COLORS,
+    PROVIDER_COLORS_DARK,
+)
+
+
+def compute_position_probabilities(row1_coef: float, col1_coef: float, col2_coef: float, col3_coef: float) -> np.ndarray:
+    """
+    Compute selection probabilities for each position in a 2x4 grid.
+
+    Args:
+        row1_coef: Coefficient for row 1 (row 2 is baseline = 0)
+        col1_coef: Coefficient for column 1 (col 4 is baseline = 0)
+        col2_coef: Coefficient for column 2
+        col3_coef: Coefficient for column 3
+
+    Returns:
+        2x4 numpy array of probabilities
+    """
+    # Position utilities: row + col coefficients
+    # Row 1, Cols 1-4: row1 + col1, row1 + col2, row1 + col3, row1 + 0
+    # Row 2, Cols 1-4: 0 + col1, 0 + col2, 0 + col3, 0 + 0
+    utilities = np.array([
+        [row1_coef + col1_coef, row1_coef + col2_coef, row1_coef + col3_coef, row1_coef],
+        [col1_coef, col2_coef, col3_coef, 0.0],
+    ])
+
+    # Softmax to get probabilities
+    exp_utilities = np.exp(utilities)
+    probabilities = exp_utilities / np.sum(exp_utilities)
+
+    return probabilities
+
+
+def plot_heatmap(
+    model_id: str,
+    probabilities: np.ndarray,
+    output_path: Path,
+    vmin: float = 0.05,
+    vmax: float = 0.25,
+    hide_colorbar: bool = True,
+) -> None:
+    """
+    Create a heatmap visualization of position probabilities.
+
+    Args:
+        model_id: Model identifier
+        probabilities: 2x4 numpy array of probabilities
+        output_path: Path to save the figure
+        vmin: Minimum value for color scale
+        vmax: Maximum value for color scale
+        hide_colorbar: Whether to hide the colorbar
+    """
+    provider = MODEL_METADATA[model_id][2]
+    display_name = MODEL_METADATA[model_id][0]
+
+    num_rows, num_cols = probabilities.shape
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+
+    # Use YlGnBu colormap like the example
+    cmap = plt.cm.YlGnBu
+    norm = mcolors.Normalize(vmin=vmin, vmax=vmax)
+
+    # Define box size and gap
+    box_width = 1.0
+    box_height = 1.0
+    gap_x = 0.1
+    gap_y = 0.1
+
+    # Draw each box
+    for r in range(num_rows):
+        for c in range(num_cols):
+            prob_value = probabilities[r, c]
+            color = cmap(norm(prob_value))
+
+            # Calculate position for the rectangle
+            x_start = c * (box_width + gap_x)
+            y_start = (num_rows - 1 - r) * (box_height + gap_y)  # Invert y-axis
+
+            rect = plt.Rectangle(
+                (x_start, y_start), box_width, box_height,
+                facecolor=color, edgecolor='black', linewidth=1.5,
+                clip_on=False
+            )
+            ax.add_patch(rect)
+
+            # Add text label for probability
+            # Determine text color based on background brightness
+            luminance = 0.299 * color[0] + 0.587 * color[1] + 0.114 * color[2]
+            text_color = 'black' if luminance > 0.5 else 'white'
+
+            ax.text(
+                x_start + box_width / 2, y_start + box_height / 2,
+                f'{prob_value:.1%}',
+                ha='center', va='center', color=text_color, fontsize=32,
+                fontfamily='Helvetica'
+            )
+
+    # Set limits and hide axes
+    ax.set_xlim(-gap_x/2, num_cols * (box_width + gap_x))
+    ax.set_ylim(-gap_y/2, num_rows * (box_height + gap_y))
+    ax.axis('off')
+
+    # Add colorbar if requested
+    if not hide_colorbar:
+        cbar = fig.colorbar(
+            plt.cm.ScalarMappable(norm=norm, cmap=cmap),
+            ax=ax, orientation='vertical', pad=0.02, shrink=0.7
+        )
+        cbar.set_label('Selection Probability', fontsize=18)
+        cbar.set_ticks(np.linspace(vmin, vmax, 5))
+        cbar.set_ticklabels([f'{val:.0%}' for val in np.linspace(vmin, vmax, 5)])
+        cbar.ax.tick_params(labelsize=14)
+
+    # Add title with model name in provider color
+    fig.text(
+        0.5, 0.95, display_name,
+        ha='center', fontsize=20, fontweight='bold',
+        color=PROVIDER_COLORS_DARK[provider]
+    )
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches='tight', facecolor='white', transparent=False)
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def generate_all_heatmaps(csv_path: Path, output_dir: Path) -> None:
+    """
+    Generate heatmaps for all models in the choice model CSV.
+
+    Args:
+        csv_path: Path to choice model coefficients CSV
+        output_dir: Directory to save heatmaps
+    """
+    # Load choice model coefficients
+    df = pd.read_csv(csv_path, index_col=0)
+
+    # Get all models that are in MODEL_METADATA
+    model_ids = [m for m in df.columns if m in MODEL_METADATA]
+
+    # Determine vmin and vmax across all models for consistent color scale
+    all_probs = []
+    for model_id in model_ids:
+        row1 = df.loc["row_1_dummy", model_id]
+        col1 = df.loc["col_1_dummy", model_id]
+        col2 = df.loc["col_2_dummy", model_id]
+        col3 = df.loc["col_3_dummy", model_id]
+
+        probs = compute_position_probabilities(row1, col1, col2, col3)
+        all_probs.extend(probs.flatten())
+
+    vmin = max(0.0, min(all_probs) - 0.01)  # Add small margin
+    vmax = min(1.0, max(all_probs) + 0.01)  # Add small margin
+
+    # Generate heatmap for each model
+    for model_id in model_ids:
+        row1 = df.loc["row_1_dummy", model_id]
+        col1 = df.loc["col_1_dummy", model_id]
+        col2 = df.loc["col_2_dummy", model_id]
+        col3 = df.loc["col_3_dummy", model_id]
+
+        probs = compute_position_probabilities(row1, col1, col2, col3)
+
+        # Use model_id as filename (safe for filesystem)
+        output_path = output_dir / f"heatmap_{model_id}.png"
+
+        plot_heatmap(
+            model_id=model_id,
+            probabilities=probs,
+            output_path=output_path,
+            vmin=vmin,
+            vmax=vmax,
+            hide_colorbar=False,  # Show colorbar for reference
+        )
+
+
+if __name__ == "__main__":
+    csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
+    output_dir = Path("artifacts/visualization/heatmaps")
+
+    generate_all_heatmaps(csv_path, output_dir)

--- a/experiments/visualization/price_equivalent_tradeoffs.py
+++ b/experiments/visualization/price_equivalent_tradeoffs.py
@@ -1,0 +1,576 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from experiments.visualization.common import (
+    MODEL_METADATA,
+    PROVIDER_COLORS,
+    PROVIDER_COLORS_DARK,
+    PROVIDER_COLORS_LIGHT,
+    apply_clean_style,
+    create_modern_legend,
+    draw_rounded_bar,
+)
+
+
+def load_choice_model_coefficients(csv_path: Path) -> pd.DataFrame:
+    """Load choice model coefficients."""
+    return pd.read_csv(csv_path, index_col=0)
+
+
+def compute_price_equivalent(beta_z: float, delta_z: float, beta_price: float) -> float:
+    """
+    Compute price-equivalent trade-off.
+
+    Formula: λ = exp(-β_z Δz / β_price)
+    Returns: Percentage change in price (λ - 1) × 100%
+
+    Args:
+        beta_z: Coefficient for feature
+        delta_z: Change in feature
+        beta_price: Coefficient for log_price
+
+    Returns:
+        Percentage change in price
+    """
+    lambda_val = np.exp(-beta_z * delta_z / beta_price)
+    return (lambda_val - 1) * 100
+
+
+def _sort_models_by_date(model_ids: list[str]) -> list[str]:
+    """Sort model IDs by release date."""
+    return sorted(model_ids, key=lambda m: MODEL_METADATA[m][1])
+
+
+def plot_single_feature_all_providers(
+    csv_path: Path,
+    output_path: Path,
+    feature_name: str,
+    coefficient_name: str,
+    delta_z: float,
+) -> None:
+    """
+    Plot price-equivalent trade-off for a single feature across all models.
+
+    X-axis labels are colored by provider.
+    """
+    df = load_choice_model_coefficients(csv_path)
+
+    # Get all models that are in MODEL_METADATA
+    model_ids = [m for m in df.columns if m in MODEL_METADATA]
+    model_ids = _sort_models_by_date(model_ids)
+
+    n_models = len(model_ids)
+
+    fig, ax = plt.subplots(figsize=(16, 5))
+
+    bar_width = 0.65
+    x = np.arange(n_models)
+
+    # Compute price-equivalent percentages for all models
+    percentages = []
+    for model_id in model_ids:
+        beta_z = df.loc[coefficient_name, model_id]
+        beta_price = df.loc["log_price", model_id]
+        pct = compute_price_equivalent(beta_z, delta_z, beta_price)
+        percentages.append(pct)
+
+    # Plot bars for each model
+    for model_idx, (model_id, pct) in enumerate(zip(model_ids, percentages)):
+        provider = MODEL_METADATA[model_id][2]
+        color = PROVIDER_COLORS[provider]
+        light_color = PROVIDER_COLORS_LIGHT[provider]
+        bx = x[model_idx]
+
+        # Determine fill based on positive/negative
+        if pct >= 0:
+            fill = light_color + "40"  # Light transparent fill for positive
+        else:
+            fill = "white"  # White fill for negative
+
+        # Draw bar
+        draw_rounded_bar(
+            ax, bx, pct, bar_width, color,
+            fill=fill,
+            rounding=0.012,
+        )
+
+        # Add value label
+        label_y = pct + (1 if pct >= 0 else -1)
+        label_va = "bottom" if pct >= 0 else "top"
+        ax.text(
+            bx, label_y,
+            f"{pct:+.1f}%",
+            ha="center", va=label_va,
+            fontsize=9, color="#333333",
+            fontweight="medium",
+        )
+
+    # Zero reference line
+    ax.axhline(y=0, color="#666666", linestyle="-", linewidth=1.5, alpha=0.5, zorder=0)
+
+    # Set x-ticks and labels (model names with dates, colored by provider)
+    labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %d, %Y')}" for m in model_ids]
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
+    ax.tick_params(axis="x", pad=10)
+
+    # Color x-tick labels by provider
+    for tick_label, model_id in zip(ax.get_xticklabels(), model_ids):
+        provider = MODEL_METADATA[model_id][2]
+        tick_label.set_color(PROVIDER_COLORS_DARK[provider])
+        tick_label.set_fontweight("semibold")
+
+    # Set axis limits
+    max_pct = max(abs(min(percentages)), abs(max(percentages))) if percentages else 0
+    y_limit = max_pct * 1.15
+    ax.set_xlim(x[0] - bar_width, x[-1] + bar_width)
+    ax.set_ylim(-y_limit, y_limit)
+
+    apply_clean_style(ax)
+    ax.set_ylabel("Price change (%)", fontsize=11, color="#555555", fontweight="medium")
+
+    # Format y-axis ticks to show percentage values
+    from matplotlib.ticker import FuncFormatter
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda y, _: f'{int(y)}'))
+
+    # Create title
+    title = f"Price-equivalent trade-off: {feature_name} (by release date)"
+    ax.set_title(title, fontsize=14, fontweight="bold", color="#222222", pad=16)
+
+    # Provider legend
+    create_modern_legend(ax, PROVIDER_COLORS, loc="upper right")
+
+    # Add note
+    note_text = "Positive = can raise price | Negative = must cut price"
+    fig.text(
+        0.5, -0.02, note_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def plot_single_feature_by_provider(
+    csv_path: Path,
+    output_path: Path,
+    feature_name: str,
+    coefficient_name: str,
+    delta_z: float,
+) -> None:
+    """
+    Plot price-equivalent trade-off for a single feature by provider.
+
+    Creates 3 subplots (one per provider) showing models sorted by release date.
+    """
+    df = load_choice_model_coefficients(csv_path)
+
+    # Get all models and group by provider
+    all_model_ids = [m for m in df.columns if m in MODEL_METADATA]
+    providers = ["Anthropic", "Google", "OpenAI"]
+    provider_models = {
+        p: _sort_models_by_date(
+            [m for m in all_model_ids if MODEL_METADATA[m][2] == p]
+        )
+        for p in providers
+    }
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
+
+    max_pcts_all = []
+
+    for ax, provider in zip(axes, providers):
+        model_ids = provider_models[provider]
+        if not model_ids:
+            continue
+
+        n_models = len(model_ids)
+        bar_width = 0.65
+        x = np.arange(n_models)
+
+        # Compute percentages
+        percentages = []
+        for model_id in model_ids:
+            beta_z = df.loc[coefficient_name, model_id]
+            beta_price = df.loc["log_price", model_id]
+            pct = compute_price_equivalent(beta_z, delta_z, beta_price)
+            percentages.append(pct)
+
+        max_pcts_all.extend([abs(p) for p in percentages])
+
+        # Plot bars
+        color = PROVIDER_COLORS[provider]
+        light_color = PROVIDER_COLORS_LIGHT[provider]
+
+        for model_idx, (model_id, pct) in enumerate(zip(model_ids, percentages)):
+            bx = x[model_idx]
+
+            # Determine fill
+            if pct >= 0:
+                fill = light_color + "40"
+            else:
+                fill = "white"
+
+            draw_rounded_bar(
+                ax, bx, pct, bar_width, color,
+                fill=fill,
+                rounding=0.012,
+            )
+
+            # Add value label
+            label_y = pct + (1 if pct >= 0 else -1)
+            label_va = "bottom" if pct >= 0 else "top"
+            ax.text(
+                bx, label_y,
+                f"{pct:+.1f}%",
+                ha="center", va=label_va,
+                fontsize=9, color="#333333",
+                fontweight="medium",
+            )
+
+        # Zero reference line
+        ax.axhline(y=0, color="#666666", linestyle="-", linewidth=1.5, alpha=0.5, zorder=0)
+
+        # Set x-ticks and labels (model names with dates)
+        labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %d, %Y')}" for m in model_ids]
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
+        ax.tick_params(axis="x", pad=10)
+
+        # Set axis limits
+        ax.set_xlim(x[0] - bar_width, x[-1] + bar_width)
+
+        apply_clean_style(ax)
+        ax.set_title(
+            provider, fontsize=13, fontweight="bold",
+            color=PROVIDER_COLORS_DARK[provider], pad=12,
+        )
+
+    # Set consistent y-axis for all subplots
+    max_pct = max(max_pcts_all) if max_pcts_all else 0
+    y_limit = max_pct * 1.15
+    axes[0].set_ylim(-y_limit, y_limit)
+
+    # Format y-axis ticks to show percentage values
+    from matplotlib.ticker import FuncFormatter
+    for ax in axes:
+        ax.yaxis.set_major_formatter(FuncFormatter(lambda y, _: f'{int(y)}'))
+
+    axes[0].set_ylabel("Price change (%)", fontsize=11, color="#555555", fontweight="medium")
+    axes[1].set_ylabel("")
+    axes[2].set_ylabel("")
+
+    # Main title
+    title = f"Price-equivalent trade-off: {feature_name} by provider (by release date)"
+    fig.suptitle(title, fontsize=15, fontweight="bold", color="#222222", y=1.02)
+
+    # Add note
+    note_text = "Positive = can raise price | Negative = must cut price"
+    fig.text(
+        0.5, -0.02, note_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def plot_combined_all_providers(
+    csv_path: Path,
+    output_path: Path,
+) -> None:
+    """
+    Plot price-equivalent trade-offs for all features across all models.
+
+    Uses different hatch patterns for different features.
+    """
+    df = load_choice_model_coefficients(csv_path)
+
+    # Define features with (name, coefficient, delta_z, hatch_pattern)
+    features = [
+        ("Overall Pick", "overall_pick_tag", 1.0, "///"),
+        ("Rating +0.1", "rating", 0.1, "\\\\\\"),
+        ("Double Reviews", "log_rating_count", np.log(2), "..."),
+        ("Sponsored Tag", "sponsored_tag", 1.0, "xxx"),
+    ]
+
+    # Get all models
+    model_ids = [m for m in df.columns if m in MODEL_METADATA]
+    model_ids = _sort_models_by_date(model_ids)
+
+    n_models = len(model_ids)
+    n_features = len(features)
+
+    fig, ax = plt.subplots(figsize=(18, 6))
+
+    bar_width = 0.18
+    group_gap = 0.1
+
+    # Calculate x positions for grouped bars
+    x_base = np.arange(n_models) * (n_features * bar_width + group_gap)
+
+    # Plot bars for each feature
+    for feat_idx, (feat_name, coef_name, delta_z, hatch) in enumerate(features):
+        x = x_base + feat_idx * bar_width
+        percentages = []
+
+        for model_id in model_ids:
+            beta_z = df.loc[coef_name, model_id]
+            beta_price = df.loc["log_price", model_id]
+            pct = compute_price_equivalent(beta_z, delta_z, beta_price)
+            percentages.append(pct)
+
+        # Plot bars with provider colors and feature-specific hatches
+        for model_idx, (model_id, pct) in enumerate(zip(model_ids, percentages)):
+            provider = MODEL_METADATA[model_id][2]
+            color = PROVIDER_COLORS[provider]
+            bx = x[model_idx]
+
+            # Draw bar with hatch pattern
+            draw_rounded_bar(
+                ax, bx, pct, bar_width, color,
+                fill="white",
+                rounding=0.012,
+                hatch=hatch,
+            )
+
+    # Zero reference line
+    ax.axhline(y=0, color="#666666", linestyle="-", linewidth=1.5, alpha=0.5, zorder=0)
+
+    # Set x-ticks at center of each group
+    x_centers = x_base + (n_features - 1) * bar_width / 2
+    labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %d, %Y')}" for m in model_ids]
+    ax.set_xticks(x_centers)
+    ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
+    ax.tick_params(axis="x", pad=10)
+
+    # Color x-tick labels by provider
+    for tick_label, model_id in zip(ax.get_xticklabels(), model_ids):
+        provider = MODEL_METADATA[model_id][2]
+        tick_label.set_color(PROVIDER_COLORS_DARK[provider])
+        tick_label.set_fontweight("semibold")
+
+    # Set axis limits
+    ax.set_xlim(x_base[0] - bar_width, x_base[-1] + n_features * bar_width)
+    ax.set_ylim(-40, 1000)
+
+    apply_clean_style(ax)
+    ax.set_ylabel("Price change (%)", fontsize=11, color="#555555", fontweight="medium")
+
+    # Format y-axis ticks to show percentage values
+    from matplotlib.ticker import FuncFormatter
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda y, _: f'{int(y)}'))
+
+    # Create title
+    title = "Price-equivalent trade-offs: All features (by release date)"
+    ax.set_title(title, fontsize=14, fontweight="bold", color="#222222", pad=16)
+
+    # Create dual legend: providers (colors) and features (hatches)
+    # Provider legend
+    from matplotlib.patches import Patch
+    provider_handles = [
+        Patch(facecolor=PROVIDER_COLORS[p], edgecolor="#333333", label=p)
+        for p in ["Anthropic", "Google", "OpenAI"]
+    ]
+
+    # Feature legend (with hatches)
+    feature_handles = [
+        Patch(facecolor="white", edgecolor="#333333", hatch=hatch, label=name)
+        for name, _, _, hatch in features
+    ]
+
+    # Two legends
+    legend1 = ax.legend(handles=provider_handles, loc="upper left", title="Provider",
+                       framealpha=0.95, fontsize=9)
+    ax.add_artist(legend1)  # Add first legend back
+    ax.legend(handles=feature_handles, loc="upper right", title="Feature",
+             framealpha=0.95, fontsize=9)
+
+    # Add note
+    note_text = "Positive = can raise price | Negative = must cut price"
+    fig.text(
+        0.5, -0.02, note_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def plot_combined_by_provider(
+    csv_path: Path,
+    output_path: Path,
+) -> None:
+    """
+    Plot price-equivalent trade-offs for all features by provider.
+
+    Creates 3 subplots with different hatch patterns for different features.
+    """
+    df = load_choice_model_coefficients(csv_path)
+
+    # Define features
+    features = [
+        ("Overall Pick", "overall_pick_tag", 1.0, "///"),
+        ("Rating +0.1", "rating", 0.1, "\\\\\\"),
+        ("Double Reviews", "log_rating_count", np.log(2), "..."),
+        ("Sponsored Tag", "sponsored_tag", 1.0, "xxx"),
+    ]
+
+    # Get all models and group by provider
+    all_model_ids = [m for m in df.columns if m in MODEL_METADATA]
+    providers = ["Anthropic", "Google", "OpenAI"]
+    provider_models = {
+        p: _sort_models_by_date(
+            [m for m in all_model_ids if MODEL_METADATA[m][2] == p]
+        )
+        for p in providers
+    }
+
+    fig, axes = plt.subplots(1, 3, figsize=(20, 6), sharey=True)
+
+    n_features = len(features)
+    bar_width = 0.18
+    group_gap = 0.08
+
+    for ax, provider in zip(axes, providers):
+        model_ids = provider_models[provider]
+        if not model_ids:
+            continue
+
+        n_models = len(model_ids)
+        color = PROVIDER_COLORS[provider]
+
+        # Calculate x positions
+        x_base = np.arange(n_models) * (n_features * bar_width + group_gap)
+
+        # Plot bars for each feature
+        for feat_idx, (feat_name, coef_name, delta_z, hatch) in enumerate(features):
+            x = x_base + feat_idx * bar_width
+            percentages = []
+
+            for model_id in model_ids:
+                beta_z = df.loc[coef_name, model_id]
+                beta_price = df.loc["log_price", model_id]
+                pct = compute_price_equivalent(beta_z, delta_z, beta_price)
+                percentages.append(pct)
+
+            # Plot bars
+            for model_idx, (model_id, pct) in enumerate(zip(model_ids, percentages)):
+                bx = x[model_idx]
+
+                draw_rounded_bar(
+                    ax, bx, pct, bar_width, color,
+                    fill="white",
+                    rounding=0.012,
+                    hatch=hatch,
+                )
+
+        # Zero reference line
+        ax.axhline(y=0, color="#666666", linestyle="-", linewidth=1.5, alpha=0.5, zorder=0)
+
+        # Set x-ticks at center of each group
+        x_centers = x_base + (n_features - 1) * bar_width / 2
+        labels = [f"{MODEL_METADATA[m][0]}\n{MODEL_METADATA[m][1].strftime('%b %d, %Y')}" for m in model_ids]
+        ax.set_xticks(x_centers)
+        ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=9)
+        ax.tick_params(axis="x", pad=10)
+
+        # Set axis limits
+        ax.set_xlim(x_base[0] - bar_width, x_base[-1] + n_features * bar_width)
+
+        apply_clean_style(ax)
+        ax.set_title(
+            provider, fontsize=13, fontweight="bold",
+            color=PROVIDER_COLORS_DARK[provider], pad=12,
+        )
+
+    # Set y-axis limits for all subplots
+    for ax in axes:
+        ax.set_ylim(-40, 1000)
+
+    # Format y-axis ticks to show percentage values
+    from matplotlib.ticker import FuncFormatter
+    for ax in axes:
+        ax.yaxis.set_major_formatter(FuncFormatter(lambda y, _: f'{int(y)}'))
+
+    axes[0].set_ylabel("Price change (%)", fontsize=11, color="#555555", fontweight="medium")
+    axes[1].set_ylabel("")
+    axes[2].set_ylabel("")
+
+    # Main title
+    title = "Price-equivalent trade-offs: All features by provider (by release date)"
+    fig.suptitle(title, fontsize=15, fontweight="bold", color="#222222", y=1.02)
+
+    # Feature legend
+    from matplotlib.patches import Patch
+    feature_handles = [
+        Patch(facecolor="white", edgecolor="#333333", hatch=hatch, label=name)
+        for name, _, _, hatch in features
+    ]
+    axes[2].legend(handles=feature_handles, loc="upper right", title="Feature",
+                  framealpha=0.95, fontsize=9)
+
+    # Add note
+    note_text = "Positive = can raise price | Negative = must cut price"
+    fig.text(
+        0.5, -0.02, note_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def generate_all_price_equivalent_plots(csv_path: Path, output_dir: Path) -> None:
+    """Generate all price-equivalent trade-off plots."""
+    # Individual feature plots
+    features = [
+        ("Overall Pick", "overall_pick_tag", 1.0, "overall_pick"),
+        ("Rating +0.1", "rating", 0.1, "rating_increase"),
+        ("Double Reviews", "log_rating_count", np.log(2), "double_reviews"),
+        ("Sponsored Tag", "sponsored_tag", 1.0, "sponsored_tag"),
+    ]
+
+    for feature_name, coefficient_name, delta_z, filename in features:
+        # All providers plot
+        plot_single_feature_all_providers(
+            csv_path,
+            output_dir / f"{filename}_all_providers.png",
+            feature_name=feature_name,
+            coefficient_name=coefficient_name,
+            delta_z=delta_z,
+        )
+
+        # By provider plot
+        plot_single_feature_by_provider(
+            csv_path,
+            output_dir / f"{filename}_by_provider.png",
+            feature_name=feature_name,
+            coefficient_name=coefficient_name,
+            delta_z=delta_z,
+        )
+
+    # Combined plots
+    plot_combined_all_providers(csv_path, output_dir / "combined_all_providers.png")
+    plot_combined_by_provider(csv_path, output_dir / "combined_by_provider.png")
+
+
+if __name__ == "__main__":
+    csv_path = Path("artifacts/analysis/20260122104301_choice_model.csv")
+    output_dir = Path("artifacts/visualization/price_equivalent_tradeoffs")
+    generate_all_price_equivalent_plots(csv_path, output_dir)

--- a/experiments/visualization/sanity_checks.py
+++ b/experiments/visualization/sanity_checks.py
@@ -276,6 +276,99 @@ def plot_category_combined(
     print(f"Saved: {output_path}")
 
 
+def generate_rating_plots(csv_file: Path, output_dir: Path) -> None:
+    """Generate all rating sanity check plots."""
+    _, tests, data = load_sanity_check_data(csv_file)
+
+    # Individual plots
+    tasks = [
+        (0, "rating_plus_0.1", "Rating +0.1 sanity check failure rates by provider", "+0.1 Rating"),
+        (1, "rating_random_low_variance", "Rating random (low variance) failure rates by provider", "Low Variance"),
+        (2, "rating_random_high_variance", "Rating random (high variance) failure rates by provider", "High Variance"),
+    ]
+
+    for task_idx, filename, title, task_label in tasks:
+        plot_single_task_by_provider(
+            data, task_idx, output_dir / f"{filename}.png",
+            title=title, task_label=task_label
+        )
+
+    # Combined plot
+    plot_category_combined(
+        data,
+        ["+0.1 Rating", "Low Variance", "High Variance"],
+        output_dir / "rating_combined.png",
+        title="Rating sanity checks combined (by release date)",
+    )
+
+
+def generate_price_plots(price_csv: Path, ar_price_csv: Path, output_dir: Path) -> None:
+    """Generate all price sanity check plots (combines price and ar_price data)."""
+    _, tests, data = load_combined_price_data(price_csv, ar_price_csv)
+
+    # Individual plots
+    tasks = [
+        (0, "price_random_low_variance", "Price random (low variance) failure rates by provider", "Random (Low Var)"),
+        (1, "price_random_high_variance", "Price random (high variance) failure rates by provider", "Random (High Var)"),
+        (2, "price_1_percent", "Price 1% reduction failure rates by provider", "1% Reduction"),
+        (3, "price_5_percent", "Price 5% reduction failure rates by provider", "5% Reduction"),
+        (4, "price_10_percent", "Price 10% reduction failure rates by provider", "10% Reduction"),
+    ]
+
+    for task_idx, filename, title, task_label in tasks:
+        plot_single_task_by_provider(
+            data, task_idx, output_dir / f"{filename}.png",
+            title=title, task_label=task_label
+        )
+
+    # Combined plot
+    plot_category_combined(
+        data,
+        ["Random (Low Var)", "Random (High Var)", "1% Reduction", "5% Reduction", "10% Reduction"],
+        output_dir / "price_combined.png",
+        title="Price sanity checks combined (by release date)",
+    )
+
+
+def generate_instruction_plots(csv_file: Path, output_dir: Path) -> None:
+    """Generate all instruction following sanity check plots."""
+    _, tests, data = load_sanity_check_data(csv_file)
+
+    # Individual plots
+    tasks = [
+        (0, "instruction_budget", "Instruction following (budget) failure rates by provider", "Budget"),
+        (1, "instruction_color", "Instruction following (color) failure rates by provider", "Color"),
+        (2, "instruction_brand", "Instruction following (brand) failure rates by provider", "Brand"),
+    ]
+
+    for task_idx, filename, title, task_label in tasks:
+        plot_single_task_by_provider(
+            data, task_idx, output_dir / f"{filename}.png",
+            title=title, task_label=task_label
+        )
+
+    # Combined plot
+    plot_category_combined(
+        data,
+        ["Budget", "Color", "Brand"],
+        output_dir / "instruction_combined.png",
+        title="Instruction following combined (by release date)",
+    )
+
+
+def generate_all_sanity_check_plots(
+    rating_csv: Path,
+    price_csv: Path,
+    ar_price_csv: Path,
+    instruction_csv: Path,
+    output_dir: Path,
+) -> None:
+    """Generate all sanity check plots."""
+    generate_rating_plots(rating_csv, output_dir)
+    generate_price_plots(price_csv, ar_price_csv, output_dir)
+    generate_instruction_plots(instruction_csv, output_dir)
+
+
 if __name__ == "__main__":
     base_output_dir = Path("artifacts/visualization/sanity_checks")
 
@@ -285,58 +378,4 @@ if __name__ == "__main__":
     ar_price_csv = Path("artifacts/analysis/20260213120645_ar_price_sanity_check.csv")
     instruction_csv = Path("artifacts/analysis/20260212101915_instruction_sanity_check.csv")
 
-    # Load data
-    _, rating_tests, rating_data = load_sanity_check_data(rating_csv)
-    _, price_tests, price_data = load_combined_price_data(price_csv, ar_price_csv)
-    _, instruction_tests, instruction_data = load_sanity_check_data(instruction_csv)
-
-    # Individual task plots
-    tasks = [
-        # Rating tasks
-        (rating_data, 0, "rating_plus_0.1", "Rating +0.1 sanity check failure rates by provider", "+0.1 Rating"),
-        (rating_data, 1, "rating_random_low_variance", "Rating random (low variance) failure rates by provider", "Low Variance"),
-        (rating_data, 2, "rating_random_high_variance", "Rating random (high variance) failure rates by provider", "High Variance"),
-
-        # Price tasks
-        (price_data, 0, "price_random_low_variance", "Price random (low variance) failure rates by provider", "Random (Low Var)"),
-        (price_data, 1, "price_random_high_variance", "Price random (high variance) failure rates by provider", "Random (High Var)"),
-        (price_data, 2, "price_1_percent", "Price 1% reduction failure rates by provider", "1% Reduction"),
-        (price_data, 3, "price_5_percent", "Price 5% reduction failure rates by provider", "5% Reduction"),
-        (price_data, 4, "price_10_percent", "Price 10% reduction failure rates by provider", "10% Reduction"),
-
-        # Instruction tasks
-        (instruction_data, 0, "instruction_budget", "Instruction following (budget) failure rates by provider", "Budget"),
-        (instruction_data, 1, "instruction_color", "Instruction following (color) failure rates by provider", "Color"),
-        (instruction_data, 2, "instruction_brand", "Instruction following (brand) failure rates by provider", "Brand"),
-    ]
-
-    for task_data, task_idx, filename, title, task_label in tasks:
-        plot_single_task_by_provider(
-            task_data,
-            task_idx,
-            base_output_dir / f"{filename}.png",
-            title=title,
-            task_label=task_label,
-        )
-
-    # Category combined plots
-    plot_category_combined(
-        rating_data,
-        ["+0.1 Rating", "Low Variance", "High Variance"],
-        base_output_dir / "rating_combined.png",
-        title="Rating sanity checks combined (by release date)",
-    )
-
-    plot_category_combined(
-        price_data,
-        ["Random (Low Var)", "Random (High Var)", "1% Reduction", "5% Reduction", "10% Reduction"],
-        base_output_dir / "price_combined.png",
-        title="Price sanity checks combined (by release date)",
-    )
-
-    plot_category_combined(
-        instruction_data,
-        ["Budget", "Color", "Brand"],
-        base_output_dir / "instruction_combined.png",
-        title="Instruction following combined (by release date)",
-    )
+    generate_all_sanity_check_plots(rating_csv, price_csv, ar_price_csv, instruction_csv, base_output_dir)

--- a/experiments/visualization/sanity_checks.py
+++ b/experiments/visualization/sanity_checks.py
@@ -1,0 +1,299 @@
+import re
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Patch
+import numpy as np
+import pandas as pd
+
+from experiments.visualization.common import (
+    DISPLAY_NAME_TO_METADATA,
+    PROVIDER_COLORS,
+    PROVIDER_COLORS_LIGHT,
+    PROVIDER_COLORS_DARK,
+    apply_clean_style,
+    draw_rounded_bar,
+    add_value_label,
+    create_modern_legend,
+    sort_display_names_by_date,
+    get_provider_for_display_name,
+)
+
+
+def _parse_value(cell: str) -> tuple[float, float]:
+    """Parse 'mean (stderr)' string. Returns (mean, stderr)."""
+    if cell.strip() == "---":
+        return np.nan, np.nan
+    match = re.match(r"([\d.]+)\s*\(([\d.]+)\)", cell.strip())
+    if not match:
+        return np.nan, np.nan
+    return float(match.group(1)), float(match.group(2))
+
+
+def load_sanity_check_data(csv_path: Path) -> tuple[list[str], list[str], dict]:
+    """Load sanity check CSV. Returns (model_names, sub_test_names, data_dict).
+
+    data_dict[model_name] = {"means": np.array, "stderrs": np.array}
+    """
+    df = pd.read_csv(csv_path)
+    model_names = df["Model"].tolist()
+    sub_tests = [c for c in df.columns if c != "Model"]
+
+    data = {}
+    for _, row in df.iterrows():
+        model = row["Model"]
+        means = []
+        stderrs = []
+        for test in sub_tests:
+            m, s = _parse_value(str(row[test]))
+            means.append(m)
+            stderrs.append(s)
+        data[model] = {"means": np.array(means), "stderrs": np.array(stderrs)}
+
+    return model_names, sub_tests, data
+
+
+def _draw_sanity_bars(
+    ax: plt.Axes,
+    model_names: list[str],
+    sub_tests: list[str],
+    data: dict,
+    show_values: bool = True,
+) -> float:
+    n_models = len(model_names)
+    n_tests = len(sub_tests)
+    bar_width = 0.12
+    group_width = n_tests * bar_width
+    group_gap = 0.25
+    x = np.arange(n_models) * (group_width + group_gap)
+
+    all_heights = []
+    label_offset_y = 0.008
+    for model_idx, model_name in enumerate(model_names):
+        provider = get_provider_for_display_name(model_name)
+        color = PROVIDER_COLORS[provider]
+        light_color = PROVIDER_COLORS_LIGHT[provider]
+        means = data[model_name]["means"]
+        stderrs = data[model_name]["stderrs"]
+        valid_means = means[~np.isnan(means)]
+        max_idx = int(np.argmax(valid_means)) if len(valid_means) > 0 else -1
+
+        for test_idx in range(n_tests):
+            bx = x[model_idx] + test_idx * bar_width
+            height = means[test_idx]
+            stderr = stderrs[test_idx]
+            if np.isnan(height):
+                continue
+            # Include label offset in height calculation to prevent cutoff
+            all_heights.append(height + stderr + label_offset_y)
+
+            # Only draw bar if height is non-zero (skip tiny/zero bars)
+            if height > 0.001:  # Threshold for ~0.1%
+                # Draw straight bar for sanity checks
+                from matplotlib.patches import Rectangle
+                x_left = bx - bar_width / 2
+                rect = Rectangle(
+                    (x_left, 0),
+                    bar_width, height,
+                    facecolor="white",
+                    edgecolor=color,
+                    linewidth=1.0,
+                    hatch="///",
+                )
+                ax.add_patch(rect)
+
+            # Enhanced error bars
+            if height > 0.001 and stderr > 0 and not np.isnan(stderr):
+                # Main error bar line
+                ax.plot(
+                    [bx, bx],
+                    [max(0, height - stderr), height + stderr],
+                    color=color, linewidth=1.2, solid_capstyle="round",
+                    alpha=0.8, zorder=5,
+                )
+                # Caps
+                cap_width = bar_width * 0.25
+                ax.plot(
+                    [bx - cap_width, bx + cap_width],
+                    [height + stderr, height + stderr],
+                    color=color, linewidth=1.2, solid_capstyle="round",
+                    alpha=0.8, zorder=5,
+                )
+                ax.plot(
+                    [bx - cap_width, bx + cap_width],
+                    [max(0, height - stderr), max(0, height - stderr)],
+                    color=color, linewidth=1.2, solid_capstyle="round",
+                    alpha=0.8, zorder=5,
+                )
+
+            # Add value labels for all bars including 0%
+            if show_values:
+                add_value_label(
+                    ax, bx, height + stderr, height,
+                    color="#666666",
+                    fontsize=7,
+                    offset_y=label_offset_y,
+                    skip_zero=False,
+                )
+
+    # sub-test labels below bars
+    for model_idx in range(n_models):
+        for test_idx in range(n_tests):
+            bx = x[model_idx] + test_idx * bar_width
+            ax.text(
+                bx, -0.01, str(test_idx + 1),
+                ha="center", va="top", fontsize=7, color="#999999",
+                fontweight="medium",
+            )
+
+    centers = x + (n_tests - 1) * bar_width / 2
+    ax.set_xticks(centers)
+    ax.set_xticklabels(model_names, rotation=0, ha="center", fontsize=9)
+    ax.tick_params(axis="x", pad=16)
+
+    max_h = max(all_heights) if all_heights else 0.1
+    x_max = x[-1] + (n_tests - 1) * bar_width + bar_width
+    ax.set_xlim(x[0] - bar_width, x_max)
+
+    apply_clean_style(ax)
+    ax.set_ylabel("Failure rate", fontsize=11, color="#555555", fontweight="medium")
+
+    return max_h
+
+
+def plot_all_providers(
+    csv_path: Path,
+    output_path: Path,
+    title: str,
+    sub_test_labels: list[str] | None = None,
+) -> None:
+    model_names, sub_tests, data = load_sanity_check_data(csv_path)
+    # filter to known models and sort by date
+    known = [n for n in model_names if n in DISPLAY_NAME_TO_METADATA]
+    known = sort_display_names_by_date(known)
+
+    fig, ax = plt.subplots(figsize=(16, 5))
+    max_h = _draw_sanity_bars(ax, known, sub_tests, data)
+    # Add extra space for text height above labels (1.15x for more room)
+    ax.set_ylim(0, max_h * 1.15)
+
+    for tick_label, model_name in zip(ax.get_xticklabels(), known):
+        provider = get_provider_for_display_name(model_name)
+        tick_label.set_color(PROVIDER_COLORS_DARK[provider])
+        tick_label.set_fontweight("semibold")
+
+    ax.set_title(title, fontsize=14, fontweight="bold", color="#222222", pad=16)
+
+    # provider legend
+    create_modern_legend(ax, PROVIDER_COLORS, loc="upper right")
+
+    # sub-test legend annotation
+    labels = sub_test_labels or sub_tests
+    label_text = "  ".join(f"{i+1}: {l}" for i, l in enumerate(labels))
+    fig.text(
+        0.5, -0.02, label_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+def plot_by_provider(
+    csv_path: Path,
+    output_path: Path,
+    title: str,
+    sub_test_labels: list[str] | None = None,
+) -> None:
+    model_names, sub_tests, data = load_sanity_check_data(csv_path)
+    known = [n for n in model_names if n in DISPLAY_NAME_TO_METADATA]
+
+    providers = ["Anthropic", "Google", "OpenAI"]
+    provider_models = {
+        p: sort_display_names_by_date(
+            [n for n in known if get_provider_for_display_name(n) == p]
+        )
+        for p in providers
+    }
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
+
+    # Collect max heights from all providers to set consistent y-axis
+    max_heights = []
+    for ax, provider in zip(axes, providers):
+        models = provider_models[provider]
+        max_h = _draw_sanity_bars(ax, models, sub_tests, data, show_values=True)
+        max_heights.append(max_h)
+        ax.set_title(
+            provider, fontsize=13, fontweight="bold",
+            color=PROVIDER_COLORS_DARK[provider], pad=12,
+        )
+
+    # Set consistent y-axis limit across all subplots based on global max
+    global_max = max(max_heights) if max_heights else 0.1
+    axes[0].set_ylim(0, global_max * 1.15)  # sharey=True propagates to all axes
+
+    axes[1].set_ylabel("")
+    axes[2].set_ylabel("")
+
+    fig.suptitle(title, fontsize=15, fontweight="bold", color="#222222", y=1.02)
+
+    labels = sub_test_labels or sub_tests
+    label_text = "  ".join(f"{i+1}: {l}" for i, l in enumerate(labels))
+    fig.text(
+        0.5, -0.02, label_text,
+        ha="center", fontsize=8, color="#666666",
+    )
+
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
+
+
+SANITY_CHECK_CONFIGS = {
+    "rating": {
+        "csv": "artifacts/analysis/20260121184134_rating_sanity_check.csv",
+        "title_all": "Rating sanity check failure rates (by release date)",
+        "title_provider": "Rating sanity check failure rates by provider (by release date)",
+        "labels": ["+0.1 Rating", "Low Variance", "High Variance"],
+        "prefix": "rating_sanity",
+    },
+    "price": {
+        "csv": "artifacts/analysis/20260212101910_price_sanity_check.csv",
+        "title_all": "Price sanity check failure rates (by release date)",
+        "title_provider": "Price sanity check failure rates by provider (by release date)",
+        "labels": ["1% Reduction", "5% Reduction", "10% Reduction"],
+        "prefix": "price_sanity",
+    },
+    "instruction": {
+        "csv": "artifacts/analysis/20260212101915_instruction_sanity_check.csv",
+        "title_all": "Instruction following failure rates (by release date)",
+        "title_provider": "Instruction following failure rates by provider (by release date)",
+        "labels": ["Budget", "Color", "Brand"],
+        "prefix": "instruction_sanity",
+    },
+}
+
+
+if __name__ == "__main__":
+    output_dir = Path("artifacts/visualization")
+
+    for key, cfg in SANITY_CHECK_CONFIGS.items():
+        csv_path = Path(cfg["csv"])
+        plot_all_providers(
+            csv_path,
+            output_dir / f"{cfg['prefix']}_all_providers.png",
+            title=cfg["title_all"],
+            sub_test_labels=cfg["labels"],
+        )
+        plot_by_provider(
+            csv_path,
+            output_dir / f"{cfg['prefix']}_by_provider.png",
+            title=cfg["title_provider"],
+            sub_test_labels=cfg["labels"],
+        )

--- a/experiments/visualization/sanity_checks.py
+++ b/experiments/visualization/sanity_checks.py
@@ -53,163 +53,67 @@ def load_sanity_check_data(csv_path: Path) -> tuple[list[str], list[str], dict]:
     return model_names, sub_tests, data
 
 
-def _draw_sanity_bars(
-    ax: plt.Axes,
-    model_names: list[str],
-    sub_tests: list[str],
+def load_combined_price_data(price_csv: Path, ar_price_csv: Path) -> tuple[list[str], list[str], dict]:
+    """Load and combine price and ar_price data.
+
+    Returns data for: Random (Low Var), Random (High Var), 1%, 5%, 10%
+    Excludes absolute price reductions (10¢, 1¢).
+    """
+    # Load both datasets
+    _, ar_tests, ar_data = load_sanity_check_data(ar_price_csv)
+    _, price_tests, price_data = load_sanity_check_data(price_csv)
+
+    # Get union of all models
+    all_models = set(ar_data.keys()) | set(price_data.keys())
+    model_names = sorted(all_models, key=lambda m: DISPLAY_NAME_TO_METADATA.get(m, ("", None, ""))[1] or "")
+
+    # Combined tests: Random (Low Var), Random (High Var), 1%, 5%, 10%
+    combined_tests = [
+        "Random (Low Variance)",  # from ar_price index 0
+        "Random (High Variance)",  # from ar_price index 1
+        "1% Price Reduction",      # from price index 0
+        "5% Price Reduction",      # from price index 1
+        "10% Price Reduction",     # from price index 2
+    ]
+
+    combined_data = {}
+    for model in model_names:
+        means = []
+        stderrs = []
+
+        # Add random variance from ar_price (indices 0, 1)
+        if model in ar_data:
+            means.extend([ar_data[model]["means"][0], ar_data[model]["means"][1]])
+            stderrs.extend([ar_data[model]["stderrs"][0], ar_data[model]["stderrs"][1]])
+        else:
+            means.extend([np.nan, np.nan])
+            stderrs.extend([np.nan, np.nan])
+
+        # Add percentage reductions from price (indices 0, 1, 2)
+        if model in price_data:
+            means.extend([price_data[model]["means"][0], price_data[model]["means"][1], price_data[model]["means"][2]])
+            stderrs.extend([price_data[model]["stderrs"][0], price_data[model]["stderrs"][1], price_data[model]["stderrs"][2]])
+        else:
+            means.extend([np.nan, np.nan, np.nan])
+            stderrs.extend([np.nan, np.nan, np.nan])
+
+        combined_data[model] = {"means": np.array(means), "stderrs": np.array(stderrs)}
+
+    return model_names, combined_tests, combined_data
+
+
+def plot_single_task_by_provider(
     data: dict,
-    show_values: bool = True,
-) -> float:
-    n_models = len(model_names)
-    n_tests = len(sub_tests)
-    bar_width = 0.12
-    group_width = n_tests * bar_width
-    group_gap = 0.25
-    x = np.arange(n_models) * (group_width + group_gap)
-
-    all_heights = []
-    label_offset_y = 0.008
-    for model_idx, model_name in enumerate(model_names):
-        provider = get_provider_for_display_name(model_name)
-        color = PROVIDER_COLORS[provider]
-        light_color = PROVIDER_COLORS_LIGHT[provider]
-        means = data[model_name]["means"]
-        stderrs = data[model_name]["stderrs"]
-        valid_means = means[~np.isnan(means)]
-        max_idx = int(np.argmax(valid_means)) if len(valid_means) > 0 else -1
-
-        for test_idx in range(n_tests):
-            bx = x[model_idx] + test_idx * bar_width
-            height = means[test_idx]
-            stderr = stderrs[test_idx]
-            if np.isnan(height):
-                continue
-            # Include label offset in height calculation to prevent cutoff
-            all_heights.append(height + stderr + label_offset_y)
-
-            # Only draw bar if height is non-zero (skip tiny/zero bars)
-            if height > 0.001:  # Threshold for ~0.1%
-                # Draw straight bar for sanity checks
-                from matplotlib.patches import Rectangle
-                x_left = bx - bar_width / 2
-                rect = Rectangle(
-                    (x_left, 0),
-                    bar_width, height,
-                    facecolor="white",
-                    edgecolor=color,
-                    linewidth=1.0,
-                    hatch="///",
-                )
-                ax.add_patch(rect)
-
-            # Enhanced error bars
-            if height > 0.001 and stderr > 0 and not np.isnan(stderr):
-                # Main error bar line
-                ax.plot(
-                    [bx, bx],
-                    [max(0, height - stderr), height + stderr],
-                    color=color, linewidth=1.2, solid_capstyle="round",
-                    alpha=0.8, zorder=5,
-                )
-                # Caps
-                cap_width = bar_width * 0.25
-                ax.plot(
-                    [bx - cap_width, bx + cap_width],
-                    [height + stderr, height + stderr],
-                    color=color, linewidth=1.2, solid_capstyle="round",
-                    alpha=0.8, zorder=5,
-                )
-                ax.plot(
-                    [bx - cap_width, bx + cap_width],
-                    [max(0, height - stderr), max(0, height - stderr)],
-                    color=color, linewidth=1.2, solid_capstyle="round",
-                    alpha=0.8, zorder=5,
-                )
-
-            # Add value labels for all bars including 0%
-            if show_values:
-                add_value_label(
-                    ax, bx, height + stderr, height,
-                    color="#666666",
-                    fontsize=7,
-                    offset_y=label_offset_y,
-                    skip_zero=False,
-                )
-
-    # sub-test labels below bars
-    for model_idx in range(n_models):
-        for test_idx in range(n_tests):
-            bx = x[model_idx] + test_idx * bar_width
-            ax.text(
-                bx, -0.01, str(test_idx + 1),
-                ha="center", va="top", fontsize=7, color="#999999",
-                fontweight="medium",
-            )
-
-    centers = x + (n_tests - 1) * bar_width / 2
-    ax.set_xticks(centers)
-    ax.set_xticklabels(model_names, rotation=0, ha="center", fontsize=9)
-    ax.tick_params(axis="x", pad=16)
-
-    max_h = max(all_heights) if all_heights else 0.1
-    x_max = x[-1] + (n_tests - 1) * bar_width + bar_width
-    ax.set_xlim(x[0] - bar_width, x_max)
-
-    apply_clean_style(ax)
-    ax.set_ylabel("Failure rate", fontsize=11, color="#555555", fontweight="medium")
-
-    return max_h
-
-
-def plot_all_providers(
-    csv_path: Path,
+    task_idx: int,
     output_path: Path,
     title: str,
-    sub_test_labels: list[str] | None = None,
+    task_label: str,
 ) -> None:
-    model_names, sub_tests, data = load_sanity_check_data(csv_path)
-    # filter to known models and sort by date
-    known = [n for n in model_names if n in DISPLAY_NAME_TO_METADATA]
-    known = sort_display_names_by_date(known)
+    """Create line graph for a single task with by-provider subplots.
 
-    fig, ax = plt.subplots(figsize=(16, 5))
-    max_h = _draw_sanity_bars(ax, known, sub_tests, data)
-    # Add extra space for text height above labels (1.15x for more room)
-    ax.set_ylim(0, max_h * 1.15)
-
-    for tick_label, model_name in zip(ax.get_xticklabels(), known):
-        provider = get_provider_for_display_name(model_name)
-        tick_label.set_color(PROVIDER_COLORS_DARK[provider])
-        tick_label.set_fontweight("semibold")
-
-    ax.set_title(title, fontsize=14, fontweight="bold", color="#222222", pad=16)
-
-    # provider legend
-    create_modern_legend(ax, PROVIDER_COLORS, loc="upper right")
-
-    # sub-test legend annotation
-    labels = sub_test_labels or sub_tests
-    label_text = "  ".join(f"{i+1}: {l}" for i, l in enumerate(labels))
-    fig.text(
-        0.5, -0.02, label_text,
-        ha="center", fontsize=8, color="#666666",
-    )
-
-    fig.tight_layout()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
-    plt.close(fig)
-    print(f"Saved: {output_path}")
-
-
-def plot_by_provider(
-    csv_path: Path,
-    output_path: Path,
-    title: str,
-    sub_test_labels: list[str] | None = None,
-) -> None:
-    model_names, sub_tests, data = load_sanity_check_data(csv_path)
-    known = [n for n in model_names if n in DISPLAY_NAME_TO_METADATA]
+    Each provider subplot shows one line (in that provider's color) for the task.
+    """
+    known = [n for n in data.keys() if n in DISPLAY_NAME_TO_METADATA]
 
     providers = ["Anthropic", "Google", "OpenAI"]
     provider_models = {
@@ -221,33 +125,56 @@ def plot_by_provider(
 
     fig, axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
 
-    # Collect max heights from all providers to set consistent y-axis
-    max_heights = []
     for ax, provider in zip(axes, providers):
         models = provider_models[provider]
-        max_h = _draw_sanity_bars(ax, models, sub_tests, data, show_values=True)
-        max_heights.append(max_h)
+        provider_color = PROVIDER_COLORS[provider]
+
+        x_positions = []
+        y_values = []
+        y_errors = []
+
+        for model_idx, model_name in enumerate(models):
+            mean = data[model_name]["means"][task_idx]
+            stderr = data[model_name]["stderrs"][task_idx]
+
+            if not np.isnan(mean):
+                x_positions.append(model_idx)
+                y_values.append(mean)
+                y_errors.append(stderr)
+
+        if x_positions:
+            # Plot single line using provider color
+            ax.plot(x_positions, y_values,
+                   marker='o', markersize=7, linewidth=2.5,
+                   color=provider_color, label=task_label, alpha=0.9)
+
+            # Add error bars
+            ax.errorbar(x_positions, y_values, yerr=y_errors,
+                       fmt='none', ecolor=provider_color, alpha=0.3,
+                       capsize=4, capthick=1.5)
+
+        # Set x-axis labels (model names with dates)
+        labels = []
+        for model_name in models:
+            model_id, release_date, _ = DISPLAY_NAME_TO_METADATA[model_name]
+            labels.append(f"{model_name}\n{release_date.strftime('%b %d, %Y')}")
+
+        ax.set_xticks(np.arange(len(models)))
+        ax.set_xticklabels(labels, rotation=0, ha='center', fontsize=9)
+        ax.tick_params(axis="x", pad=10)
+
+        # Styling
+        apply_clean_style(ax)
         ax.set_title(
             provider, fontsize=13, fontweight="bold",
             color=PROVIDER_COLORS_DARK[provider], pad=12,
         )
 
-    # Set consistent y-axis limit across all subplots based on global max
-    global_max = max(max_heights) if max_heights else 0.1
-    axes[0].set_ylim(0, global_max * 1.15)  # sharey=True propagates to all axes
-
+    axes[0].set_ylabel("Failure Rate", fontsize=11, color="#555555", fontweight="medium")
     axes[1].set_ylabel("")
     axes[2].set_ylabel("")
 
     fig.suptitle(title, fontsize=15, fontweight="bold", color="#222222", y=1.02)
-
-    labels = sub_test_labels or sub_tests
-    label_text = "  ".join(f"{i+1}: {l}" for i, l in enumerate(labels))
-    fig.text(
-        0.5, -0.02, label_text,
-        ha="center", fontsize=8, color="#666666",
-    )
-
     fig.tight_layout()
     output_path.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
@@ -255,45 +182,161 @@ def plot_by_provider(
     print(f"Saved: {output_path}")
 
 
-SANITY_CHECK_CONFIGS = {
-    "rating": {
-        "csv": "artifacts/analysis/20260121184134_rating_sanity_check.csv",
-        "title_all": "Rating sanity check failure rates (by release date)",
-        "title_provider": "Rating sanity check failure rates by provider (by release date)",
-        "labels": ["+0.1 Rating", "Low Variance", "High Variance"],
-        "prefix": "rating_sanity",
-    },
-    "price": {
-        "csv": "artifacts/analysis/20260212101910_price_sanity_check.csv",
-        "title_all": "Price sanity check failure rates (by release date)",
-        "title_provider": "Price sanity check failure rates by provider (by release date)",
-        "labels": ["1% Reduction", "5% Reduction", "10% Reduction"],
-        "prefix": "price_sanity",
-    },
-    "instruction": {
-        "csv": "artifacts/analysis/20260212101915_instruction_sanity_check.csv",
-        "title_all": "Instruction following failure rates (by release date)",
-        "title_provider": "Instruction following failure rates by provider (by release date)",
-        "labels": ["Budget", "Color", "Brand"],
-        "prefix": "instruction_sanity",
-    },
-}
+def plot_category_combined(
+    data: dict,
+    task_labels: list[str],
+    output_path: Path,
+    title: str,
+) -> None:
+    """Create combined plot for all tasks within a category by provider.
+
+    Each provider subplot shows multiple lines (one per task), all in that provider's color,
+    with different line styles/markers to distinguish tasks.
+    """
+    known = [n for n in data.keys() if n in DISPLAY_NAME_TO_METADATA]
+
+    providers = ["Anthropic", "Google", "OpenAI"]
+    provider_models = {
+        p: sort_display_names_by_date(
+            [n for n in known if get_provider_for_display_name(n) == p]
+        )
+        for p in providers
+    }
+
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
+
+    # Line styles and markers for different tasks
+    line_styles = ['-', '--', '-.', ':', '-']
+    markers = ['o', 's', '^', 'D', 'v']
+
+    for ax, provider in zip(axes, providers):
+        models = provider_models[provider]
+        provider_color = PROVIDER_COLORS[provider]
+
+        # Plot one line per task
+        for task_idx, label in enumerate(task_labels):
+            x_positions = []
+            y_values = []
+            y_errors = []
+
+            for model_idx, model_name in enumerate(models):
+                mean = data[model_name]["means"][task_idx]
+                stderr = data[model_name]["stderrs"][task_idx]
+
+                if not np.isnan(mean):
+                    x_positions.append(model_idx)
+                    y_values.append(mean)
+                    y_errors.append(stderr)
+
+            if x_positions:
+                linestyle = line_styles[task_idx % len(line_styles)]
+                marker = markers[task_idx % len(markers)]
+
+                # Plot line using provider color
+                ax.plot(x_positions, y_values,
+                       marker=marker, markersize=7, linewidth=2.5,
+                       linestyle=linestyle,
+                       color=provider_color, label=label, alpha=0.9)
+
+                # Add error bars
+                ax.errorbar(x_positions, y_values, yerr=y_errors,
+                           fmt='none', ecolor=provider_color, alpha=0.3,
+                           capsize=4, capthick=1.5)
+
+        # Set x-axis labels (model names with dates)
+        labels = []
+        for model_name in models:
+            model_id, release_date, _ = DISPLAY_NAME_TO_METADATA[model_name]
+            labels.append(f"{model_name}\n{release_date.strftime('%b %d, %Y')}")
+
+        ax.set_xticks(np.arange(len(models)))
+        ax.set_xticklabels(labels, rotation=0, ha='center', fontsize=9)
+        ax.tick_params(axis="x", pad=10)
+
+        # Styling
+        apply_clean_style(ax)
+        ax.set_title(
+            provider, fontsize=13, fontweight="bold",
+            color=PROVIDER_COLORS_DARK[provider], pad=12,
+        )
+
+        # Add legend
+        if provider == "Anthropic":  # Only add legend to first subplot
+            ax.legend(fontsize=9, loc="best", framealpha=0.95, title="Test Condition")
+
+    axes[0].set_ylabel("Failure Rate", fontsize=11, color="#555555", fontweight="medium")
+    axes[1].set_ylabel("")
+    axes[2].set_ylabel("")
+
+    fig.suptitle(title, fontsize=15, fontweight="bold", color="#222222", y=1.02)
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved: {output_path}")
 
 
 if __name__ == "__main__":
-    output_dir = Path("artifacts/visualization")
+    base_output_dir = Path("artifacts/visualization/sanity_checks")
 
-    for key, cfg in SANITY_CHECK_CONFIGS.items():
-        csv_path = Path(cfg["csv"])
-        plot_all_providers(
-            csv_path,
-            output_dir / f"{cfg['prefix']}_all_providers.png",
-            title=cfg["title_all"],
-            sub_test_labels=cfg["labels"],
+    # File paths
+    rating_csv = Path("artifacts/analysis/20260121184134_rating_sanity_check.csv")
+    price_csv = Path("artifacts/analysis/20260212101910_price_sanity_check.csv")
+    ar_price_csv = Path("artifacts/analysis/20260213120645_ar_price_sanity_check.csv")
+    instruction_csv = Path("artifacts/analysis/20260212101915_instruction_sanity_check.csv")
+
+    # Load data
+    _, rating_tests, rating_data = load_sanity_check_data(rating_csv)
+    _, price_tests, price_data = load_combined_price_data(price_csv, ar_price_csv)
+    _, instruction_tests, instruction_data = load_sanity_check_data(instruction_csv)
+
+    # Individual task plots
+    tasks = [
+        # Rating tasks
+        (rating_data, 0, "rating_plus_0.1", "Rating +0.1 sanity check failure rates by provider", "+0.1 Rating"),
+        (rating_data, 1, "rating_random_low_variance", "Rating random (low variance) failure rates by provider", "Low Variance"),
+        (rating_data, 2, "rating_random_high_variance", "Rating random (high variance) failure rates by provider", "High Variance"),
+
+        # Price tasks
+        (price_data, 0, "price_random_low_variance", "Price random (low variance) failure rates by provider", "Random (Low Var)"),
+        (price_data, 1, "price_random_high_variance", "Price random (high variance) failure rates by provider", "Random (High Var)"),
+        (price_data, 2, "price_1_percent", "Price 1% reduction failure rates by provider", "1% Reduction"),
+        (price_data, 3, "price_5_percent", "Price 5% reduction failure rates by provider", "5% Reduction"),
+        (price_data, 4, "price_10_percent", "Price 10% reduction failure rates by provider", "10% Reduction"),
+
+        # Instruction tasks
+        (instruction_data, 0, "instruction_budget", "Instruction following (budget) failure rates by provider", "Budget"),
+        (instruction_data, 1, "instruction_color", "Instruction following (color) failure rates by provider", "Color"),
+        (instruction_data, 2, "instruction_brand", "Instruction following (brand) failure rates by provider", "Brand"),
+    ]
+
+    for task_data, task_idx, filename, title, task_label in tasks:
+        plot_single_task_by_provider(
+            task_data,
+            task_idx,
+            base_output_dir / f"{filename}.png",
+            title=title,
+            task_label=task_label,
         )
-        plot_by_provider(
-            csv_path,
-            output_dir / f"{cfg['prefix']}_by_provider.png",
-            title=cfg["title_provider"],
-            sub_test_labels=cfg["labels"],
-        )
+
+    # Category combined plots
+    plot_category_combined(
+        rating_data,
+        ["+0.1 Rating", "Low Variance", "High Variance"],
+        base_output_dir / "rating_combined.png",
+        title="Rating sanity checks combined (by release date)",
+    )
+
+    plot_category_combined(
+        price_data,
+        ["Random (Low Var)", "Random (High Var)", "1% Reduction", "5% Reduction", "10% Reduction"],
+        base_output_dir / "price_combined.png",
+        title="Price sanity checks combined (by release date)",
+    )
+
+    plot_category_combined(
+        instruction_data,
+        ["Budget", "Color", "Brand"],
+        base_output_dir / "instruction_combined.png",
+        title="Instruction following combined (by release date)",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ members = [
 
 [project.scripts]
 analysis = "experiments.analysis.cli:app"
+visualization = "experiments.visualization.cli:app"
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
## Summary
Add comprehensive visualization scripts for analyzing model performance through sanity checks and position bias metrics.

### New Features
- **Sanity Check Visualizations**: Generate failure rate plots for rating, price, and instruction following sanity checks
- **Position Bias Visualizations**: Analyze choice model position bias across 8 grid positions
- **Dual View Modes**: Both all-provider comparison and provider-specific breakdown views
- **Modern Styling**: Clean, professional charts with official brand colors (Anthropic, Google, OpenAI)

### Technical Improvements
- Hatched bar patterns with straight edges for sanity checks, rounded for choice model
- Proper y-axis scaling across provider subplots (fixes inconsistent limits)
- Skip rendering bars for zero/negligible values while showing labels
- Rotated labels (90°) for dense choice model plots
- Error bars with caps for sanity check data
- All percentages displayed including 0% values

### Files Added
- `experiments/visualization/common.py` - Shared utilities and styling
- `experiments/visualization/sanity_checks.py` - Sanity check failure rate plots
- `experiments/visualization/choice_model_position_bias.py` - Position bias analysis plots

### Output
Generates PNG files in `artifacts/visualization/`:
- Rating, price, and instruction sanity check plots
- Position bias plots (all providers and by provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)